### PR TITLE
v0.1.1 PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Check installer dry run
         run: ./install.sh --dry-run
 
+      - name: Check installer uninstall dry run
+        run: ./install.sh --uninstall --dry-run
+
+      - name: Check installer purge dry run
+        run: ./install.sh --uninstall --purge --dry-run
+
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "edgepad"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "evdev",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "edgepad"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-description = "Correctness-first Wayland touchpad edge gesture daemon"
+description = "Touchpad edge gestures for Linux/Wayland"
 repository = "https://github.com/assembledev/edgepad"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ curl -fsSL https://raw.githubusercontent.com/assembledev/edgepad/main/install.sh
 
 The installer downloads the x86_64 Linux release binary, installs udev rules, writes a default config to `~/.config/edgepad/edgepad.toml`, installs a systemd user service, starts it, and runs `edgepad doctor`.
 
+Uninstall files created by the release installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/assembledev/edgepad/main/install.sh | sh -s -- --uninstall
+```
+
+This keeps `~/.config/edgepad/edgepad.toml`. To remove the config too:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/assembledev/edgepad/main/install.sh | sh -s -- --uninstall --purge
+```
+
 ### Nix
 
 Build and run from the repository:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Watch logs:
 journalctl --user -u edgepad.service -f
 ```
 
+For a foreground run, `edgepad daemon` reads `~/.config/edgepad/edgepad.toml` by default.
+
 ## Gesture config
 
 `device` can be `"auto"` or an explicit event node:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cargo run -- --help
 
 ## Quick start
 
-Check device access and service state:
+Check config, device access, action executables, and service state:
 
 ```bash
 edgepad doctor
@@ -246,7 +246,7 @@ Replace `/dev/input/eventX` with the touchpad node reported by `edgepad devices`
 
 ```text
 edgepad devices     List readable input devices and touchpad candidates
-edgepad doctor      Check runtime prerequisites and service health
+edgepad doctor      Check config, runtime prerequisites, actions, and service health
 edgepad daemon      Run the live edge-gesture proxy
 edgepad dump        Capture touchpad events into a replay fixture
 edgepad proxy       Run a bounded live proxy session for diagnostics

--- a/install.sh
+++ b/install.sh
@@ -11,12 +11,19 @@ SYSTEMD_USER_DIR="${CONFIG_HOME}/systemd/user"
 SERVICE_FILE="${SYSTEMD_USER_DIR}/edgepad.service"
 UDEV_RULE_FILE="/etc/udev/rules.d/70-edgepad.rules"
 DRY_RUN=0
+MODE="install"
+PURGE=0
 
 usage() {
     cat <<'EOF'
-usage: install.sh [--dry-run]
+usage: install.sh [--dry-run] [--uninstall] [--purge]
 
 Installs edgepad for the current user from GitHub Releases.
+
+Options:
+  --dry-run       Print the install or uninstall plan without changing files
+  --uninstall     Remove files installed by this script
+  --purge         With --uninstall, also remove ~/.config/edgepad
 
 Environment:
   EDGEPAD_REPO=owner/repo      GitHub repository [default: assembledev/edgepad]
@@ -42,6 +49,10 @@ run() {
     "$@"
 }
 
+run_optional() {
+    "$@" || warn "command failed: $*"
+}
+
 need_command() {
     command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
@@ -60,7 +71,29 @@ sudo_run_optional() {
     sudo "$@" || warn "command failed: sudo $*"
 }
 
-print_dry_run_plan() {
+remove_file_if_present() {
+    path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        rm -f "$path"
+        info "Removed: ${path}"
+    else
+        info "Not present: ${path}"
+    fi
+}
+
+sudo_remove_file_if_present() {
+    path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        sudo_run rm -f "$path"
+        info "Removed: ${path}"
+        return 0
+    fi
+
+    info "Not present: ${path}"
+    return 1
+}
+
+print_install_dry_run_plan() {
     info "Dry run: edgepad install preview"
     info ""
     info "Release source:"
@@ -109,10 +142,49 @@ print_dry_run_plan() {
     info "Dry run complete; no files were downloaded or changed."
 }
 
+print_uninstall_dry_run_plan() {
+    info "Dry run: edgepad uninstall preview"
+    info ""
+    info "Would run:"
+    info "  systemctl --user disable --now edgepad.service"
+    info ""
+    info "Would remove user service:"
+    info "  ${SERVICE_FILE}"
+    info "Would run:"
+    info "  systemctl --user daemon-reload"
+    info ""
+    info "Would remove binary:"
+    info "  ${BIN_DIR}/edgepad"
+    info ""
+    info "Would remove udev rule with sudo:"
+    info "  ${UDEV_RULE_FILE}"
+    info "Would run if udev rule is removed:"
+    info "  sudo udevadm control --reload"
+    info "  sudo udevadm trigger --subsystem-match=input --action=change"
+    info "  sudo udevadm trigger --subsystem-match=misc --action=change"
+    info ""
+    if [ "$PURGE" -eq 1 ]; then
+        info "Would remove config directory:"
+        info "  ${CONFIG_DIR}"
+    else
+        info "Would keep config:"
+        info "  ${CONFIG_FILE}"
+        info "Use --uninstall --purge to remove ${CONFIG_DIR}."
+    fi
+    info ""
+    info "Dry run complete; no files were changed."
+}
+
 for arg in "$@"; do
     case "$arg" in
         --dry-run)
             DRY_RUN=1
+            ;;
+        --uninstall)
+            MODE="uninstall"
+            ;;
+        --purge)
+            PURGE=1
             ;;
         -h|--help)
             usage
@@ -125,8 +197,48 @@ for arg in "$@"; do
     esac
 done
 
+if [ "$PURGE" -eq 1 ] && [ "$MODE" != "uninstall" ]; then
+    die "--purge requires --uninstall"
+fi
+
 if [ "$(id -u)" -eq 0 ]; then
     die "do not run install.sh as root; it installs a user service and uses sudo only for udev rules"
+fi
+
+if [ "$MODE" = "uninstall" ]; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+        print_uninstall_dry_run_plan
+        exit 0
+    fi
+
+    need_command sudo
+    need_command systemctl
+    need_command udevadm
+
+    info "Uninstalling edgepad"
+    run_optional systemctl --user disable --now edgepad.service
+    remove_file_if_present "$SERVICE_FILE"
+    run_optional systemctl --user daemon-reload
+    remove_file_if_present "${BIN_DIR}/edgepad"
+    if sudo_remove_file_if_present "$UDEV_RULE_FILE"; then
+        sudo_run udevadm control --reload
+        sudo_run_optional udevadm trigger --subsystem-match=input --action=change
+        sudo_run_optional udevadm trigger --subsystem-match=misc --action=change
+    fi
+
+    if [ "$PURGE" -eq 1 ]; then
+        if [ -e "$CONFIG_DIR" ] || [ -L "$CONFIG_DIR" ]; then
+            rm -rf "$CONFIG_DIR"
+            info "Removed: ${CONFIG_DIR}"
+        else
+            info "Not present: ${CONFIG_DIR}"
+        fi
+    else
+        info "Keeping config: ${CONFIG_FILE}"
+    fi
+
+    info "edgepad uninstalled"
+    exit 0
 fi
 
 kernel="$(uname -s)"
@@ -168,7 +280,7 @@ cleanup() {
 trap cleanup EXIT HUP INT TERM
 
 if [ "$DRY_RUN" -eq 1 ]; then
-    print_dry_run_plan
+    print_install_dry_run_plan
     exit 0
 fi
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -235,7 +235,7 @@ impl ActionDispatcher {
                     gesture.tracking_id
                 );
             }
-            GestureActionConfig::Command { argv } => self.enqueue_command(argv.clone()),
+            GestureActionConfig::Command { argv } => self.enqueue_command(gesture, argv.clone()),
         }
     }
 
@@ -262,13 +262,13 @@ impl ActionDispatcher {
         self.stats.snapshot()
     }
 
-    fn enqueue_command(&self, argv: Vec<String>) {
+    fn enqueue_command(&self, gesture: Gesture, argv: Vec<String>) {
         let Some(sender) = &self.sender else {
             self.stats.increment_dropped_commands();
             return;
         };
 
-        match sender.try_send(ActionCommand { argv }) {
+        match sender.try_send(ActionCommand { gesture, argv }) {
             Ok(()) => self.stats.increment_queued_commands(),
             Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => {
                 self.stats.increment_dropped_commands();
@@ -285,6 +285,7 @@ impl GestureHandler for ActionDispatcher {
 
 #[derive(Debug, Clone)]
 struct ActionCommand {
+    gesture: Gesture,
     argv: Vec<String>,
 }
 
@@ -310,16 +311,31 @@ fn run_action_worker<R>(
             Ok(_) => {
                 stats.increment_failed_commands();
                 eprintln!(
-                    "edgepad action command exited unsuccessfully: {:?}",
+                    "edgepad action command exited unsuccessfully: {} argv={:?}",
+                    action_command_context(&command),
                     command.argv
                 );
             }
             Err(err) => {
                 stats.increment_failed_commands();
-                eprintln!("edgepad action command failed: {err}");
+                eprintln!(
+                    "edgepad action command failed: {} argv={:?}: {err}",
+                    action_command_context(&command),
+                    command.argv
+                );
             }
         }
     }
+}
+
+fn action_command_context(command: &ActionCommand) -> String {
+    format!(
+        "zone={} direction={} slot={} tracking_id={}",
+        zone_name(command.gesture.zone),
+        direction_name(command.gesture.direction),
+        command.gesture.slot,
+        command.gesture.tracking_id
+    )
 }
 
 fn wait_for_action_worker_shutdown(worker: &JoinHandle<()>, timeout: Duration) -> bool {
@@ -599,6 +615,19 @@ mod tests {
         assert_eq!(stats.succeeded_commands, 0);
         assert_eq!(stats.failed_commands, 1);
         assert_eq!(stats.worker_shutdown_timeouts, 0);
+    }
+
+    #[test]
+    fn action_command_context_includes_gesture_identity() {
+        let command = ActionCommand {
+            gesture: gesture(Zone::Right, GestureDirection::Up),
+            argv: vec!["notify-send".to_string(), "edgepad".to_string()],
+        };
+
+        assert_eq!(
+            action_command_context(&command),
+            "zone=right direction=up slot=0 tracking_id=42"
+        );
     }
 
     fn wait_for_started_command(dispatcher: &ActionDispatcher) {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -220,6 +220,7 @@ impl ActionDispatcher {
             .find(|binding| binding.matches(&gesture))
         else {
             self.stats.increment_unmatched_gestures();
+            eprintln!("edgepad action unmatched: {}", gesture_context(gesture));
             return;
         };
 
@@ -329,12 +330,16 @@ fn run_action_worker<R>(
 }
 
 fn action_command_context(command: &ActionCommand) -> String {
+    gesture_context(command.gesture)
+}
+
+fn gesture_context(gesture: Gesture) -> String {
     format!(
         "zone={} direction={} slot={} tracking_id={}",
-        zone_name(command.gesture.zone),
-        direction_name(command.gesture.direction),
-        command.gesture.slot,
-        command.gesture.tracking_id
+        zone_name(gesture.zone),
+        direction_name(gesture.direction),
+        gesture.slot,
+        gesture.tracking_id
     )
 }
 
@@ -627,6 +632,14 @@ mod tests {
         assert_eq!(
             action_command_context(&command),
             "zone=right direction=up slot=0 tracking_id=42"
+        );
+    }
+
+    #[test]
+    fn gesture_context_includes_gesture_identity() {
+        assert_eq!(
+            gesture_context(gesture(Zone::Top, GestureDirection::Left)),
+            "zone=top direction=left slot=0 tracking_id=42"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -165,6 +166,21 @@ pub fn load_edgepad_config(path: &Path) -> Result<EdgepadConfig, String> {
         .map_err(|err| format!("failed to read config {}: {err}", path.display()))?;
     EdgepadConfig::parse(&input)
         .map_err(|err| format!("failed to parse config {}: {err}", path.display()))
+}
+
+pub fn default_edgepad_config_path() -> Result<PathBuf, String> {
+    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(config_home).join("edgepad/edgepad.toml"));
+    }
+
+    if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(home).join(".config/edgepad/edgepad.toml"));
+    }
+
+    Err(
+        "config path was not provided; pass --config <file> or set XDG_CONFIG_HOME/HOME"
+            .to_string(),
+    )
 }
 
 pub fn parse_edge_width(raw_value: &str) -> Result<f32, String> {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,16 +1,24 @@
+use std::collections::BTreeMap;
 use std::env;
-use std::fs::OpenOptions;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use evdev::Device;
 
-use crate::config::DeviceConfig;
+use crate::config::{
+    default_edgepad_config_path, load_edgepad_config, DeviceConfig, EdgepadConfig,
+    GestureActionConfig,
+};
+use crate::core::{GestureDirection, Zone};
 use crate::device::{discover_device_report, format_device_line, touchpad_candidates};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DoctorConfig {
-    pub device: DeviceConfig,
+    pub config_path: Option<PathBuf>,
+    pub device_override: Option<DeviceConfig>,
     pub input_root: PathBuf,
     pub uinput_path: PathBuf,
     pub service_name: String,
@@ -19,7 +27,8 @@ pub struct DoctorConfig {
 impl Default for DoctorConfig {
     fn default() -> Self {
         Self {
-            device: DeviceConfig::Auto,
+            config_path: None,
+            device_override: None,
             input_root: PathBuf::from("/dev/input"),
             uinput_path: PathBuf::from("/dev/uinput"),
             service_name: "edgepad.service".to_string(),
@@ -85,7 +94,18 @@ pub struct DoctorCounts {
 
 pub fn run_doctor(config: &DoctorConfig) -> DoctorReport {
     let mut report = DoctorReport::default();
-    let touchpad_path = check_touchpad_selection(config, &mut report);
+    let loaded_config = check_config(config, &mut report);
+    let effective_device = check_config_device(
+        loaded_config.as_ref(),
+        config.device_override.as_ref(),
+        &mut report,
+    );
+    if let Some(loaded_config) = loaded_config.as_ref() {
+        check_action_executables(loaded_config, &mut report);
+    }
+
+    let touchpad_path =
+        check_touchpad_selection(&effective_device, &config.input_root, &mut report);
 
     let touchpad_readable = check_touchpad_readable(touchpad_path.as_deref(), &mut report);
     let uinput_readable = check_uinput(&config.uinput_path, &mut report);
@@ -109,8 +129,283 @@ pub fn run_doctor(config: &DoctorConfig) -> DoctorReport {
     report
 }
 
-fn check_touchpad_selection(config: &DoctorConfig, report: &mut DoctorReport) -> Option<PathBuf> {
-    match &config.device {
+fn check_config(config: &DoctorConfig, report: &mut DoctorReport) -> Option<EdgepadConfig> {
+    let path = match &config.config_path {
+        Some(path) => path.clone(),
+        None => match default_edgepad_config_path() {
+            Ok(path) => path,
+            Err(err) => {
+                report.checks.push(DoctorCheck {
+                    status: CheckStatus::Fail,
+                    name: "config path",
+                    detail: err,
+                });
+                return None;
+            }
+        },
+    };
+
+    match fs::metadata(&path) {
+        Ok(metadata) if metadata.is_file() => report.checks.push(DoctorCheck {
+            status: CheckStatus::Ok,
+            name: "config path",
+            detail: format!("{}", path.display()),
+        }),
+        Ok(_) => {
+            report.checks.push(DoctorCheck {
+                status: CheckStatus::Fail,
+                name: "config path",
+                detail: format!("not a file: {}", path.display()),
+            });
+            return None;
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            report.checks.push(DoctorCheck {
+                status: CheckStatus::Fail,
+                name: "config path",
+                detail: format!(
+                    "not found: {}; pass --config <file> or create ~/.config/edgepad/edgepad.toml",
+                    path.display()
+                ),
+            });
+            return None;
+        }
+        Err(err) => {
+            report.checks.push(DoctorCheck {
+                status: CheckStatus::Fail,
+                name: "config path",
+                detail: format!("failed to inspect {}: {err}", path.display()),
+            });
+            return None;
+        }
+    }
+
+    match load_edgepad_config(&path) {
+        Ok(edgepad_config) => {
+            report.checks.push(DoctorCheck {
+                status: CheckStatus::Ok,
+                name: "config parse",
+                detail: format!(
+                    "device={} edge_width={:.3} gesture_bindings={}",
+                    device_config_label(&edgepad_config.device),
+                    edgepad_config.edge_width,
+                    edgepad_config.gestures.len()
+                ),
+            });
+            check_gesture_bindings(&edgepad_config, report);
+            Some(edgepad_config)
+        }
+        Err(err) => {
+            report.checks.push(DoctorCheck {
+                status: CheckStatus::Fail,
+                name: "config parse",
+                detail: err,
+            });
+            None
+        }
+    }
+}
+
+fn check_gesture_bindings(config: &EdgepadConfig, report: &mut DoctorReport) {
+    if config.gestures.is_empty() {
+        report.checks.push(DoctorCheck {
+            status: CheckStatus::Fail,
+            name: "gesture bindings",
+            detail: "no gesture bindings configured; add at least one [[gestures]] entry"
+                .to_string(),
+        });
+        return;
+    }
+
+    report.checks.push(DoctorCheck {
+        status: CheckStatus::Ok,
+        name: "gesture bindings",
+        detail: format!("{} gesture binding(s) configured", config.gestures.len()),
+    });
+}
+
+fn check_config_device(
+    loaded_config: Option<&EdgepadConfig>,
+    device_override: Option<&DeviceConfig>,
+    report: &mut DoctorReport,
+) -> DeviceConfig {
+    match (loaded_config, device_override) {
+        (_, Some(device)) => {
+            let detail = match loaded_config {
+                Some(config) => format!(
+                    "{} from config overridden by --device {}",
+                    device_config_label(&config.device),
+                    device_config_label(device)
+                ),
+                None => format!("using --device {}", device_config_label(device)),
+            };
+            report.checks.push(DoctorCheck {
+                status: CheckStatus::Warn,
+                name: "config device",
+                detail,
+            });
+            device.clone()
+        }
+        (Some(config), None) => {
+            report.checks.push(DoctorCheck {
+                status: CheckStatus::Ok,
+                name: "config device",
+                detail: format!("using {}", device_config_label(&config.device)),
+            });
+            config.device.clone()
+        }
+        (None, None) => {
+            report.checks.push(DoctorCheck {
+                status: CheckStatus::Warn,
+                name: "config device",
+                detail: "using device=auto because config was not loaded".to_string(),
+            });
+            DeviceConfig::Auto
+        }
+    }
+}
+
+fn check_action_executables(config: &EdgepadConfig, report: &mut DoctorReport) {
+    if config.gestures.is_empty() {
+        return;
+    }
+
+    let mut usages = BTreeMap::<String, Vec<String>>::new();
+    for (index, binding) in config.gestures.iter().enumerate() {
+        if let GestureActionConfig::Command { argv } = &binding.action {
+            if let Some(program) = argv.first() {
+                usages
+                    .entry(program.clone())
+                    .or_default()
+                    .push(gesture_binding_label(
+                        index,
+                        binding.zone,
+                        binding.direction,
+                    ));
+            }
+        }
+    }
+
+    if usages.is_empty() {
+        report.checks.push(DoctorCheck {
+            status: CheckStatus::Ok,
+            name: "action executable",
+            detail: "no command actions configured".to_string(),
+        });
+        return;
+    }
+
+    for (program, bindings) in usages {
+        let usage = format_binding_usage(&bindings);
+        match action_executable_status(&program) {
+            ActionExecutableStatus::Found(path) => report.checks.push(DoctorCheck {
+                status: CheckStatus::Ok,
+                name: "action executable",
+                detail: format!("{program} found at {} for {usage}", path.display()),
+            }),
+            ActionExecutableStatus::AbsolutePathExecutable => report.checks.push(DoctorCheck {
+                status: CheckStatus::Ok,
+                name: "action executable",
+                detail: format!("{program} is executable for {usage}"),
+            }),
+            ActionExecutableStatus::RelativePathExecutable => report.checks.push(DoctorCheck {
+                status: CheckStatus::Warn,
+                name: "action executable",
+                detail: format!(
+                    "{program} is a relative executable path for {usage}; user services may run from a different directory"
+                ),
+            }),
+            ActionExecutableStatus::Missing(message) => report.checks.push(DoctorCheck {
+                status: CheckStatus::Fail,
+                name: "action executable",
+                detail: format!("{message} for {usage}"),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ActionExecutableStatus {
+    Found(PathBuf),
+    AbsolutePathExecutable,
+    RelativePathExecutable,
+    Missing(String),
+}
+
+fn action_executable_status(program: &str) -> ActionExecutableStatus {
+    if program.contains('/') {
+        return path_executable_status(Path::new(program));
+    }
+
+    match find_executable_in_path(program, env::var_os("PATH")) {
+        Some(path) => ActionExecutableStatus::Found(path),
+        None => ActionExecutableStatus::Missing(format!("{program} not found in PATH")),
+    }
+}
+
+fn path_executable_status(path: &Path) -> ActionExecutableStatus {
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() && metadata.permissions().mode() & 0o111 != 0 => {
+            if path.is_absolute() {
+                ActionExecutableStatus::AbsolutePathExecutable
+            } else {
+                ActionExecutableStatus::RelativePathExecutable
+            }
+        }
+        Ok(metadata) if metadata.is_file() => ActionExecutableStatus::Missing(format!(
+            "{} exists but is not executable",
+            path.display()
+        )),
+        Ok(_) => ActionExecutableStatus::Missing(format!("{} is not a file", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            ActionExecutableStatus::Missing(format!("{} not found", path.display()))
+        }
+        Err(err) => {
+            ActionExecutableStatus::Missing(format!("failed to inspect {}: {err}", path.display()))
+        }
+    }
+}
+
+fn find_executable_in_path(program: &str, path_env: Option<OsString>) -> Option<PathBuf> {
+    let path_env = path_env?;
+    env::split_paths(&path_env)
+        .map(|dir| dir.join(program))
+        .find(|candidate| {
+            fs::metadata(candidate)
+                .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        })
+}
+
+fn format_binding_usage(bindings: &[String]) -> String {
+    match bindings {
+        [] => "0 binding(s)".to_string(),
+        [binding] => binding.clone(),
+        _ => format!("{} binding(s): {}", bindings.len(), bindings.join(", ")),
+    }
+}
+
+fn gesture_binding_label(index: usize, zone: Zone, direction: GestureDirection) -> String {
+    format!(
+        "gestures[{index}] {}.{}",
+        zone_name(zone),
+        direction_name(direction)
+    )
+}
+
+fn device_config_label(device: &DeviceConfig) -> String {
+    match device {
+        DeviceConfig::Auto => "device=auto".to_string(),
+        DeviceConfig::Path(path) => format!("device={}", path.display()),
+    }
+}
+
+fn check_touchpad_selection(
+    device: &DeviceConfig,
+    input_root: &Path,
+    report: &mut DoctorReport,
+) -> Option<PathBuf> {
+    match device {
         DeviceConfig::Path(path) => {
             report.checks.push(DoctorCheck {
                 status: CheckStatus::Warn,
@@ -122,15 +417,12 @@ fn check_touchpad_selection(config: &DoctorConfig, report: &mut DoctorReport) ->
             });
             Some(path.clone())
         }
-        DeviceConfig::Auto => match discover_device_report(&config.input_root) {
+        DeviceConfig::Auto => match discover_device_report(input_root) {
             Ok(discovery) if discovery.event_node_count == 0 => {
                 report.checks.push(DoctorCheck {
                     status: CheckStatus::Fail,
                     name: "touchpad auto-detect",
-                    detail: format!(
-                        "no event devices found under {}",
-                        config.input_root.display()
-                    ),
+                    detail: format!("no event devices found under {}", input_root.display()),
                 });
                 None
             }
@@ -141,7 +433,7 @@ fn check_touchpad_selection(config: &DoctorConfig, report: &mut DoctorReport) ->
                     detail: format!(
                         "{} event node(s) found under {}, but none were readable",
                         discovery.event_node_count,
-                        config.input_root.display()
+                        input_root.display()
                     ),
                 });
                 None
@@ -189,7 +481,7 @@ fn check_touchpad_selection(config: &DoctorConfig, report: &mut DoctorReport) ->
                 report.checks.push(DoctorCheck {
                     status: CheckStatus::Fail,
                     name: "touchpad auto-detect",
-                    detail: format!("failed to list {}: {err}", config.input_root.display()),
+                    detail: format!("failed to list {}: {err}", input_root.display()),
                 });
                 None
             }
@@ -641,9 +933,29 @@ fn property_value<'a>(output: &'a str, key: &str) -> Option<&'a str> {
         .find_map(|line| line.strip_prefix(&format!("{key}=")))
 }
 
+fn zone_name(zone: Zone) -> &'static str {
+    match zone {
+        Zone::Left => "left",
+        Zone::Right => "right",
+        Zone::Top => "top",
+        Zone::Bottom => "bottom",
+    }
+}
+
+fn direction_name(direction: GestureDirection) -> &'static str {
+    match direction {
+        GestureDirection::Up => "up",
+        GestureDirection::Down => "down",
+        GestureDirection::Left => "left",
+        GestureDirection::Right => "right",
+        GestureDirection::Tap => "tap",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::GestureBindingConfig;
 
     #[test]
     fn parses_current_tags_from_udevadm_properties() {
@@ -686,6 +998,93 @@ mod tests {
     }
 
     #[test]
+    fn config_device_uses_config_when_no_cli_override_is_present() {
+        let mut report = DoctorReport::default();
+        let config = EdgepadConfig {
+            device: DeviceConfig::Path(PathBuf::from("/dev/input/event7")),
+            edge_width: 0.10,
+            gestures: Vec::new(),
+        };
+
+        let device = check_config_device(Some(&config), None, &mut report);
+
+        assert_eq!(
+            device,
+            DeviceConfig::Path(PathBuf::from("/dev/input/event7"))
+        );
+        assert_eq!(report.checks[0].status, CheckStatus::Ok);
+        assert!(report.checks[0].detail.contains("/dev/input/event7"));
+    }
+
+    #[test]
+    fn config_device_uses_cli_override_when_present() {
+        let mut report = DoctorReport::default();
+        let config = EdgepadConfig {
+            device: DeviceConfig::Auto,
+            edge_width: 0.10,
+            gestures: Vec::new(),
+        };
+
+        let device = check_config_device(
+            Some(&config),
+            Some(&DeviceConfig::Path(PathBuf::from("/dev/input/event9"))),
+            &mut report,
+        );
+
+        assert_eq!(
+            device,
+            DeviceConfig::Path(PathBuf::from("/dev/input/event9"))
+        );
+        assert_eq!(report.checks[0].status, CheckStatus::Warn);
+        assert!(report.checks[0].detail.contains("overridden by --device"));
+    }
+
+    #[test]
+    fn action_executable_check_reports_missing_path_command() {
+        let mut report = DoctorReport::default();
+        let config = EdgepadConfig {
+            device: DeviceConfig::Auto,
+            edge_width: 0.10,
+            gestures: vec![GestureBindingConfig {
+                zone: Zone::Right,
+                direction: GestureDirection::Up,
+                action: GestureActionConfig::Command {
+                    argv: vec!["/tmp/edgepad-definitely-missing-command".to_string()],
+                },
+            }],
+        };
+
+        check_action_executables(&config, &mut report);
+
+        assert_eq!(report.checks.len(), 1);
+        assert_eq!(report.checks[0].status, CheckStatus::Fail);
+        assert!(report.checks[0].detail.contains("not found"));
+        assert!(report.checks[0].detail.contains("gestures[0] right.up"));
+    }
+
+    #[test]
+    fn find_executable_in_path_finds_executable_file() {
+        let root = unique_temp_dir("edgepad-doctor-path");
+        let bin_dir = root.join("bin");
+        let program = bin_dir.join("edgepad-test-tool");
+        fs::create_dir_all(&bin_dir).expect("bin dir should be created");
+        fs::write(&program, "#!/bin/sh\n").expect("test executable should be written");
+        let mut permissions = fs::metadata(&program)
+            .expect("metadata should be available")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).expect("permissions should be updated");
+
+        let found = find_executable_in_path(
+            "edgepad-test-tool",
+            Some(OsString::from(bin_dir.display().to_string())),
+        );
+
+        assert_eq!(found, Some(program));
+        fs::remove_dir_all(root).expect("temp dir should be removed");
+    }
+
+    #[test]
     fn report_counts_failures_warnings_and_successes() {
         let report = DoctorReport {
             checks: vec![
@@ -716,5 +1115,9 @@ mod tests {
                 fail: 1
             }
         );
+    }
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("{}-{}", prefix, std::process::id()))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,7 @@ Usage:
 
 Options:
       --config <file>             TOML config path
+                                  [default: $XDG_CONFIG_HOME/edgepad/edgepad.toml or ~/.config/edgepad/edgepad.toml]
       --device auto|<event-node>  Touchpad device selection [default: auto]
       --input-root <input-root>   Input device directory for auto-detect [default: /dev/input]
       --edge-width F              Edge zone width as a fraction of the touchpad axis
@@ -250,6 +251,7 @@ struct ProxyArgs {
 
 struct DaemonArgs {
     config: EdgepadConfig,
+    config_path: PathBuf,
     input_root: PathBuf,
 }
 
@@ -404,18 +406,67 @@ fn parse_daemon_args(mut args: impl Iterator<Item = String>) -> Result<DaemonArg
         }
     }
 
-    let mut config = match config_path {
-        Some(path) => load_edgepad_config(&path)?,
-        None => EdgepadConfig::default(),
+    let config_path = match config_path {
+        Some(path) => path,
+        None => default_daemon_config_path()?,
     };
+    let mut config = load_daemon_config(&config_path)?;
     if let Some(device) = device_override {
         config.device = device;
     }
     if let Some(edge_width) = edge_width_override {
         config.edge_width = edge_width;
     }
+    validate_daemon_config(&config, &config_path)?;
 
-    Ok(DaemonArgs { config, input_root })
+    Ok(DaemonArgs {
+        config,
+        config_path,
+        input_root,
+    })
+}
+
+fn default_daemon_config_path() -> Result<PathBuf, String> {
+    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(config_home).join("edgepad/edgepad.toml"));
+    }
+
+    if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(home).join(".config/edgepad/edgepad.toml"));
+    }
+
+    Err(
+        "daemon config path was not provided; pass --config <file> or set XDG_CONFIG_HOME/HOME"
+            .to_string(),
+    )
+}
+
+fn load_daemon_config(path: &Path) -> Result<EdgepadConfig, String> {
+    match fs::metadata(path) {
+        Ok(metadata) if !metadata.is_file() => {
+            Err(format!("daemon config path is not a file: {}", path.display()))
+        }
+        Ok(_) => load_edgepad_config(path),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Err(format!(
+            "daemon config not found: {}; pass --config <file> or create it from edgepad.toml.example",
+            path.display()
+        )),
+        Err(err) => Err(format!(
+            "failed to inspect daemon config {}: {err}",
+            path.display()
+        )),
+    }
+}
+
+fn validate_daemon_config(config: &EdgepadConfig, config_path: &Path) -> Result<(), String> {
+    if config.gestures.is_empty() {
+        return Err(format!(
+            "daemon config {} has no gesture bindings; add at least one [[gestures]] entry",
+            config_path.display()
+        ));
+    }
+
+    Ok(())
 }
 
 fn parse_positive_frame_limit(raw_value: &str) -> Result<usize, String> {
@@ -643,6 +694,7 @@ fn daemon(args: &DaemonArgs) -> Result<(), String> {
     install_daemon_signal_handlers(stop.clone())?;
     let mut action_dispatcher =
         ActionDispatcher::new(args.config.gestures.clone(), DAEMON_ACTION_QUEUE_CAPACITY)?;
+    eprintln!("edgepad daemon: config={}", args.config_path.display());
     eprintln!("edgepad daemon: press Ctrl+C to stop");
 
     let run_result = run_daemon_proxy_with_startup_retry(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use edgepad::actions::{ActionDispatcher, ActionDispatcherStats};
-use edgepad::config::{load_edgepad_config, DeviceConfig, EdgepadConfig};
+use edgepad::config::{
+    default_edgepad_config_path, load_edgepad_config, DeviceConfig, EdgepadConfig,
+};
 use edgepad::core::{AxisRange, Capabilities, EdgeWidths, Engine, GestureDirection, Zone};
 use edgepad::device::{discover_device_report, format_device_line, touchpad_candidates};
 use edgepad::doctor::{run_doctor, DoctorConfig, DoctorReport};
@@ -27,7 +29,7 @@ use edgepad::raw::{
 use edgepad::replay::{parse_replay_file, replay_stats, run_frames};
 use evdev::raw_stream::RawDevice;
 
-const USAGE: &str = "usage: edgepad replay <fixture.ev> | edgepad replay-raw <raw.ev> | edgepad devices [--root <input-root>] [--all] | edgepad doctor [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>] | edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw] | edgepad proxy --device <event-node> --frames N (--dry-run | --uinput --grab) [--edge-width F] | edgepad daemon [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F]";
+const USAGE: &str = "usage: edgepad replay <fixture.ev> | edgepad replay-raw <raw.ev> | edgepad devices [--root <input-root>] [--all] | edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>] | edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw] | edgepad proxy --device <event-node> --frames N (--dry-run | --uinput --grab) [--edge-width F] | edgepad daemon [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F]";
 const HELP: &str = "\
 Usage:
   edgepad <command> [options]
@@ -105,13 +107,15 @@ Options:
       --input-root <input-root>   Input device directory for auto-detect [default: /dev/input]
       --edge-width F              Edge zone width as a fraction of the touchpad axis
 ";
-const DOCTOR_USAGE: &str = "usage: edgepad doctor [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>]";
+const DOCTOR_USAGE: &str = "usage: edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>]";
 const DOCTOR_HELP: &str = "\
 Usage:
-  edgepad doctor [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>]
+  edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>]
 
 Options:
-      --device auto|<event-node>  Touchpad device selection [default: auto]
+      --config <file>             TOML config path
+                                  [default: $XDG_CONFIG_HOME/edgepad/edgepad.toml or ~/.config/edgepad/edgepad.toml]
+      --device auto|<event-node>  Override touchpad device selection from config
       --input-root <input-root>   Input device directory for auto-detect [default: /dev/input]
       --uinput <path>             uinput device path [default: /dev/uinput]
       --service <unit>            systemd user unit to inspect [default: edgepad.service]
@@ -277,9 +281,13 @@ fn parse_doctor_args(mut args: impl Iterator<Item = String>) -> Result<DoctorCon
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
+            "--config" => {
+                config.config_path =
+                    Some(args.next().ok_or_else(|| DOCTOR_USAGE.to_string())?.into());
+            }
             "--device" => {
                 let raw_value = args.next().ok_or_else(|| DOCTOR_USAGE.to_string())?;
-                config.device = DeviceConfig::parse(&raw_value)?;
+                config.device_override = Some(DeviceConfig::parse(&raw_value)?);
             }
             "--input-root" => {
                 config.input_root = args.next().ok_or_else(|| DOCTOR_USAGE.to_string())?.into();
@@ -408,7 +416,7 @@ fn parse_daemon_args(mut args: impl Iterator<Item = String>) -> Result<DaemonArg
 
     let config_path = match config_path {
         Some(path) => path,
-        None => default_daemon_config_path()?,
+        None => default_edgepad_config_path()?,
     };
     let mut config = load_daemon_config(&config_path)?;
     if let Some(device) = device_override {
@@ -424,21 +432,6 @@ fn parse_daemon_args(mut args: impl Iterator<Item = String>) -> Result<DaemonArg
         config_path,
         input_root,
     })
-}
-
-fn default_daemon_config_path() -> Result<PathBuf, String> {
-    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
-        return Ok(PathBuf::from(config_home).join("edgepad/edgepad.toml"));
-    }
-
-    if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
-        return Ok(PathBuf::from(home).join(".config/edgepad/edgepad.toml"));
-    }
-
-    Err(
-        "daemon config path was not provided; pass --config <file> or set XDG_CONFIG_HOME/HOME"
-            .to_string(),
-    )
 }
 
 fn load_daemon_config(path: &Path) -> Result<EdgepadConfig, String> {
@@ -1181,7 +1174,8 @@ mod tests {
     fn doctor_args_default_to_auto_device_and_system_paths() {
         let args = parse_doctor_args(Vec::<String>::new().into_iter()).expect("doctor args parse");
 
-        assert_eq!(args.device, DeviceConfig::Auto);
+        assert_eq!(args.config_path, None);
+        assert_eq!(args.device_override, None);
         assert_eq!(args.input_root, PathBuf::from("/dev/input"));
         assert_eq!(args.uinput_path, PathBuf::from("/dev/uinput"));
         assert_eq!(args.service_name, "edgepad.service");
@@ -1191,6 +1185,8 @@ mod tests {
     fn doctor_args_accept_overrides() {
         let args = parse_doctor_args(
             [
+                "--config",
+                "/tmp/edgepad.toml",
                 "--device",
                 "/tmp/input/event7",
                 "--input-root",
@@ -1205,9 +1201,10 @@ mod tests {
         )
         .expect("doctor args parse");
 
+        assert_eq!(args.config_path, Some(PathBuf::from("/tmp/edgepad.toml")));
         assert_eq!(
-            args.device,
-            DeviceConfig::Path(PathBuf::from("/tmp/input/event7"))
+            args.device_override,
+            Some(DeviceConfig::Path(PathBuf::from("/tmp/input/event7")))
         );
         assert_eq!(args.input_root, PathBuf::from("/tmp/input"));
         assert_eq!(args.uinput_path, PathBuf::from("/tmp/uinput"));

--- a/tests/daemon_cli.rs
+++ b/tests/daemon_cli.rs
@@ -7,12 +7,16 @@ fn edgepad() -> Command {
 
 #[test]
 fn daemon_cli_accepts_explicit_device_before_device_open() {
+    let config_path = unique_temp_path("edgepad-daemon-explicit-device-config");
     let missing_device = unique_temp_path("edgepad-missing-daemon-device");
+    write_daemon_config(&config_path, "auto");
     let _ = std::fs::remove_file(&missing_device);
 
     let output = edgepad()
         .env("EDGEPAD_DAEMON_STARTUP_RETRY_MS", "0")
         .arg("daemon")
+        .arg("--config")
+        .arg(&config_path)
         .arg("--device")
         .arg(&missing_device)
         .arg("--edge-width")
@@ -33,6 +37,8 @@ fn daemon_cli_accepts_explicit_device_before_device_open() {
         stderr.contains(&missing_device.display().to_string()),
         "stderr was: {stderr}"
     );
+
+    std::fs::remove_file(config_path).expect("config should be removed");
 }
 
 #[test]
@@ -68,12 +74,16 @@ fn daemon_cli_rejects_invalid_edge_width_before_auto_discovery() {
 
 #[test]
 fn daemon_cli_reports_empty_auto_input_root_without_touching_real_hardware() {
+    let config_path = unique_temp_path("edgepad-daemon-empty-input-root-config");
     let root = unique_temp_dir("edgepad-daemon-empty-input-root");
+    write_daemon_config(&config_path, "auto");
     std::fs::create_dir_all(&root).expect("temp root should be created");
 
     let output = edgepad()
         .env("EDGEPAD_DAEMON_STARTUP_RETRY_MS", "0")
         .arg("daemon")
+        .arg("--config")
+        .arg(&config_path)
         .arg("--device")
         .arg("auto")
         .arg("--input-root")
@@ -92,17 +102,22 @@ fn daemon_cli_reports_empty_auto_input_root_without_touching_real_hardware() {
         "stderr was: {stderr}"
     );
 
+    std::fs::remove_file(config_path).expect("config should be removed");
     std::fs::remove_dir_all(root).expect("temp root should be removed");
 }
 
 #[test]
 fn daemon_cli_times_out_startup_retry_with_clear_error() {
+    let config_path = unique_temp_path("edgepad-daemon-retry-empty-input-root-config");
     let root = unique_temp_dir("edgepad-daemon-retry-empty-input-root");
+    write_daemon_config(&config_path, "auto");
     std::fs::create_dir_all(&root).expect("temp root should be created");
 
     let output = edgepad()
         .env("EDGEPAD_DAEMON_STARTUP_RETRY_MS", "1")
         .arg("daemon")
+        .arg("--config")
+        .arg(&config_path)
         .arg("--device")
         .arg("auto")
         .arg("--input-root")
@@ -121,7 +136,106 @@ fn daemon_cli_times_out_startup_retry_with_clear_error() {
         "stderr was: {stderr}"
     );
 
+    std::fs::remove_file(config_path).expect("config should be removed");
     std::fs::remove_dir_all(root).expect("temp root should be removed");
+}
+
+#[test]
+fn daemon_cli_reports_missing_default_config_path() {
+    let config_home = unique_temp_dir("edgepad-daemon-missing-default-config-home");
+    let _ = std::fs::remove_dir_all(&config_home);
+    std::fs::create_dir_all(&config_home).expect("config home should be created");
+    let expected_config = config_home.join("edgepad/edgepad.toml");
+
+    let output = edgepad()
+        .env("EDGEPAD_DAEMON_STARTUP_RETRY_MS", "0")
+        .env("XDG_CONFIG_HOME", &config_home)
+        .arg("daemon")
+        .output()
+        .expect("edgepad binary should run");
+
+    assert!(!output.status.success(), "missing config should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("daemon config not found"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains(&expected_config.display().to_string()),
+        "stderr was: {stderr}"
+    );
+
+    std::fs::remove_dir_all(config_home).expect("config home should be removed");
+}
+
+#[test]
+fn daemon_cli_loads_default_config_path_from_xdg_config_home() {
+    let config_home = unique_temp_dir("edgepad-daemon-xdg-config-home");
+    let config_path = config_home.join("edgepad/edgepad.toml");
+    let missing_device = unique_temp_path("edgepad-daemon-xdg-config-device");
+    let _ = std::fs::remove_dir_all(&config_home);
+    let _ = std::fs::remove_file(&missing_device);
+    write_daemon_config(&config_path, &missing_device.display().to_string());
+
+    let output = edgepad()
+        .env("EDGEPAD_DAEMON_STARTUP_RETRY_MS", "0")
+        .env("XDG_CONFIG_HOME", &config_home)
+        .arg("daemon")
+        .output()
+        .expect("edgepad binary should run");
+
+    assert!(
+        !output.status.success(),
+        "daemon should still fail for missing configured device"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&format!("edgepad daemon: config={}", config_path.display())),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("failed to open device"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains(&missing_device.display().to_string()),
+        "stderr was: {stderr}"
+    );
+
+    std::fs::remove_dir_all(config_home).expect("config home should be removed");
+}
+
+#[test]
+fn daemon_cli_rejects_empty_gesture_config_before_device_open() {
+    let config_path = unique_temp_path("edgepad-daemon-empty-gesture-config");
+    let missing_device = unique_temp_path("edgepad-daemon-empty-gesture-device");
+    let _ = std::fs::remove_file(&missing_device);
+    std::fs::write(
+        &config_path,
+        format!("device = \"{}\"\n", missing_device.display()),
+    )
+    .expect("config should be written");
+
+    let output = edgepad()
+        .env("EDGEPAD_DAEMON_STARTUP_RETRY_MS", "0")
+        .arg("daemon")
+        .arg("--config")
+        .arg(&config_path)
+        .output()
+        .expect("edgepad binary should run");
+
+    assert!(!output.status.success(), "empty gestures should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("has no gesture bindings"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        !stderr.contains("failed to open device"),
+        "daemon should reject config before opening the device, stderr was: {stderr}"
+    );
+
+    std::fs::remove_file(config_path).expect("config should be removed");
 }
 
 #[test]
@@ -185,4 +299,25 @@ fn unique_temp_path(prefix: &str) -> PathBuf {
 
 fn unique_temp_dir(prefix: &str) -> PathBuf {
     std::env::temp_dir().join(format!("{}-{}", prefix, std::process::id()))
+}
+
+fn write_daemon_config(path: &std::path::Path, device: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("config parent should be created");
+    }
+    std::fs::write(
+        path,
+        format!(
+            r#"
+device = "{device}"
+edge_width = 0.20
+
+[[gestures]]
+zone = "left"
+direction = "right"
+action = ["notify-send", "edgepad", "left-right"]
+"#,
+        ),
+    )
+    .expect("config should be written");
 }

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -1,0 +1,192 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn edgepad() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_edgepad"))
+}
+
+#[test]
+fn doctor_cli_checks_config_and_action_executables() {
+    let root = unique_temp_dir("edgepad-doctor-cli-input-root");
+    let config_path = unique_temp_path("edgepad-doctor-cli-config");
+    let missing_uinput = unique_temp_path("edgepad-doctor-cli-uinput");
+    let missing_action = unique_temp_path("edgepad-doctor-cli-missing-action");
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_file(&config_path);
+    let _ = fs::remove_file(&missing_uinput);
+    let _ = fs::remove_file(&missing_action);
+    fs::create_dir_all(&root).expect("input root should be created");
+    write_config(&config_path, "auto", &missing_action);
+
+    let output = edgepad()
+        .arg("doctor")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--input-root")
+        .arg(&root)
+        .arg("--uinput")
+        .arg(&missing_uinput)
+        .output()
+        .expect("edgepad binary should run");
+
+    assert!(!output.status.success(), "doctor should report failures");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("config path"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains(&config_path.display().to_string()),
+        "stdout was: {stdout}"
+    );
+    assert!(stdout.contains("config parse"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains("gesture_bindings=1"),
+        "stdout was: {stdout}"
+    );
+    assert!(stdout.contains("action executable"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains(&missing_action.display().to_string()),
+        "stdout was: {stdout}"
+    );
+    assert!(stdout.contains("not found"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains("gestures[0] right.up"),
+        "stdout was: {stdout}"
+    );
+
+    fs::remove_dir_all(root).expect("input root should be removed");
+    fs::remove_file(config_path).expect("config should be removed");
+}
+
+#[test]
+fn doctor_cli_uses_config_device_without_cli_override() {
+    let root = unique_temp_dir("edgepad-doctor-cli-config-device-root");
+    let config_path = unique_temp_path("edgepad-doctor-cli-config-device");
+    let missing_device = unique_temp_path("edgepad-doctor-cli-configured-device");
+    let missing_uinput = unique_temp_path("edgepad-doctor-cli-config-device-uinput");
+    let action = unique_temp_executable("edgepad-doctor-cli-action");
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_file(&config_path);
+    let _ = fs::remove_file(&missing_device);
+    let _ = fs::remove_file(&missing_uinput);
+    fs::create_dir_all(&root).expect("input root should be created");
+    write_config(&config_path, &missing_device.display().to_string(), &action);
+
+    let output = edgepad()
+        .arg("doctor")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--input-root")
+        .arg(&root)
+        .arg("--uinput")
+        .arg(&missing_uinput)
+        .output()
+        .expect("edgepad binary should run");
+
+    assert!(!output.status.success(), "doctor should report failures");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("config device"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains(&missing_device.display().to_string()),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("skipped because explicit device was provided"),
+        "stdout was: {stdout}"
+    );
+
+    fs::remove_dir_all(root).expect("input root should be removed");
+    fs::remove_file(config_path).expect("config should be removed");
+    fs::remove_file(action).expect("action executable should be removed");
+}
+
+#[test]
+fn doctor_cli_device_override_wins_over_config_device() {
+    let root = unique_temp_dir("edgepad-doctor-cli-device-override-root");
+    let config_path = unique_temp_path("edgepad-doctor-cli-device-override-config");
+    let configured_device = unique_temp_path("edgepad-doctor-cli-configured-device");
+    let override_device = unique_temp_path("edgepad-doctor-cli-override-device");
+    let missing_uinput = unique_temp_path("edgepad-doctor-cli-device-override-uinput");
+    let action = unique_temp_executable("edgepad-doctor-cli-override-action");
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_file(&config_path);
+    let _ = fs::remove_file(&configured_device);
+    let _ = fs::remove_file(&override_device);
+    let _ = fs::remove_file(&missing_uinput);
+    fs::create_dir_all(&root).expect("input root should be created");
+    write_config(
+        &config_path,
+        &configured_device.display().to_string(),
+        &action,
+    );
+
+    let output = edgepad()
+        .arg("doctor")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--device")
+        .arg(&override_device)
+        .arg("--input-root")
+        .arg(&root)
+        .arg("--uinput")
+        .arg(&missing_uinput)
+        .output()
+        .expect("edgepad binary should run");
+
+    assert!(!output.status.success(), "doctor should report failures");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("overridden by --device"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains(&configured_device.display().to_string()),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains(&override_device.display().to_string()),
+        "stdout was: {stdout}"
+    );
+
+    fs::remove_dir_all(root).expect("input root should be removed");
+    fs::remove_file(config_path).expect("config should be removed");
+    fs::remove_file(action).expect("action executable should be removed");
+}
+
+fn write_config(path: &Path, device: &str, action: &Path) {
+    fs::write(
+        path,
+        format!(
+            r#"
+device = "{device}"
+edge_width = 0.10
+
+[[gestures]]
+zone = "right"
+direction = "up"
+action = ["{}"]
+"#,
+            action.display()
+        ),
+    )
+    .expect("config should be written");
+}
+
+fn unique_temp_executable(prefix: &str) -> PathBuf {
+    let path = unique_temp_path(prefix);
+    fs::write(&path, "#!/bin/sh\n").expect("action executable should be written");
+    let mut permissions = fs::metadata(&path)
+        .expect("metadata should be available")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("permissions should be updated");
+    path
+}
+
+fn unique_temp_path(prefix: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("{}-{}", prefix, std::process::id()))
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("{}-{}", prefix, std::process::id()))
+}

--- a/tests/help_cli.rs
+++ b/tests/help_cli.rs
@@ -63,7 +63,7 @@ fn subcommand_help_flags_print_command_help() {
         ("devices", "edgepad devices [--root <input-root>] [--all]"),
         (
             "doctor",
-            "edgepad doctor [--device auto|<event-node>] [--input-root <input-root>]",
+            "edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>]",
         ),
         (
             "daemon",


### PR DESCRIPTION
## Summary

  Prepare edgepad v0.1.1.

  This release improves first-run and troubleshooting UX without changing the gesture config format.

  ## Changes

  - Load the default daemon config from `~/.config/edgepad/edgepad.toml` when `--config` is not passed.
  - Make `edgepad doctor` validate config files, gesture bindings, configured devices, and action executables.
  - Log recognized gestures that have no matching configured action.
  - Add installer uninstall support with `--uninstall` and config removal via `--purge`.
  - Add release bump to `0.1.1`.

  ## Validation

  - `cargo fmt --check`
  - `cargo test`
  - `cargo clippy --all-targets -- -D warnings`
  - `nix flake check`
  - `./install.sh --dry-run`
  - `./install.sh --uninstall --dry-run`
  - `./install.sh --uninstall --purge --dry-run`