### PR TITLE
Release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "edgepad"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "evdev",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgepad"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Touchpad edge gestures for Linux/Wayland"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ cargo run -- --help
 
 ## Quick start
 
-Check config, device access, action executables, and service state:
+Check the current daemon, config, device, zones, and actions:
+
+```bash
+edgepad status
+```
+
+Run deeper diagnostics for device access, action executables, and service state:
 
 ```bash
 edgepad doctor
@@ -258,6 +264,7 @@ Replace `/dev/input/eventX` with the touchpad node reported by `edgepad devices`
 
 ```text
 edgepad devices     List readable input devices and touchpad candidates
+edgepad status      Show a short daemon/config/device summary
 edgepad doctor      Check config, runtime prerequisites, actions, and service health
 edgepad daemon      Run the live edge-gesture proxy
 edgepad dump        Capture touchpad events into a replay fixture

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use serde::Deserialize;
 
-use crate::core::{Gesture, GestureDirection, Zone};
+use crate::core::{EdgeWidths, Gesture, GestureDirection, Zone};
 use crate::device::{
     discover_device_report, format_device_line, touchpad_candidates, DiscoveryReport,
 };
@@ -59,6 +59,23 @@ impl EdgepadConfig {
         }
 
         Ok(config)
+    }
+
+    pub fn active_edge_widths(&self) -> EdgeWidths {
+        EdgeWidths {
+            left: self.zone_edge_width(Zone::Left),
+            right: self.zone_edge_width(Zone::Right),
+            top: self.zone_edge_width(Zone::Top),
+            bottom: self.zone_edge_width(Zone::Bottom),
+        }
+    }
+
+    fn zone_edge_width(&self, zone: Zone) -> f32 {
+        if self.gestures.iter().any(|binding| binding.zone == zone) {
+            self.edge_width
+        } else {
+            0.0
+        }
     }
 }
 
@@ -431,6 +448,36 @@ mod tests {
                     },
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn edgepad_config_activates_only_zones_with_gesture_bindings() {
+        let config = EdgepadConfig::parse(
+            r#"
+            edge_width = 0.20
+
+            [[gestures]]
+            zone = "right"
+            direction = "up"
+            action = ["notify-send", "right-up"]
+
+            [[gestures]]
+            zone = "top"
+            direction = "left"
+            action = ["notify-send", "top-left"]
+            "#,
+        )
+        .expect("config should parse");
+
+        assert_eq!(
+            config.active_edge_widths(),
+            EdgeWidths {
+                left: 0.0,
+                right: 0.20,
+                top: 0.20,
+                bottom: 0.0,
+            }
         );
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -12,7 +12,7 @@ use crate::config::{
     default_edgepad_config_path, load_edgepad_config, DeviceConfig, EdgepadConfig,
     GestureActionConfig,
 };
-use crate::core::{GestureDirection, Zone};
+use crate::core::{EdgeWidths, GestureDirection, Zone};
 use crate::device::{discover_device_report, format_device_line, touchpad_candidates};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -222,6 +222,54 @@ fn check_gesture_bindings(config: &EdgepadConfig, report: &mut DoctorReport) {
         name: "gesture bindings",
         detail: format!("{} gesture binding(s) configured", config.gestures.len()),
     });
+    report.checks.push(DoctorCheck {
+        status: CheckStatus::Ok,
+        name: "active zones",
+        detail: active_zones_detail(config),
+    });
+}
+
+fn active_zones_detail(config: &EdgepadConfig) -> String {
+    let active_zones: Vec<Zone> = ordered_zones()
+        .iter()
+        .copied()
+        .filter(|zone| config.gestures.iter().any(|binding| binding.zone == *zone))
+        .collect();
+    let inactive_zones: Vec<Zone> = ordered_zones()
+        .iter()
+        .copied()
+        .filter(|zone| !active_zones.contains(zone))
+        .collect();
+
+    format!(
+        "active_zones={} inactive_zones={} edge_widths={}",
+        zone_list_label(&active_zones),
+        zone_list_label(&inactive_zones),
+        edge_widths_label(config.active_edge_widths())
+    )
+}
+
+fn ordered_zones() -> [Zone; 4] {
+    [Zone::Left, Zone::Right, Zone::Top, Zone::Bottom]
+}
+
+fn zone_list_label(zones: &[Zone]) -> String {
+    if zones.is_empty() {
+        return "none".to_string();
+    }
+
+    zones
+        .iter()
+        .map(|zone| zone_name(*zone))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn edge_widths_label(widths: EdgeWidths) -> String {
+    format!(
+        "left={:.3} right={:.3} top={:.3} bottom={:.3}",
+        widths.left, widths.right, widths.top, widths.bottom
+    )
 }
 
 fn check_config_device(
@@ -955,7 +1003,7 @@ fn direction_name(direction: GestureDirection) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::GestureBindingConfig;
+    use crate::config::{GestureActionConfig, GestureBindingConfig};
 
     #[test]
     fn parses_current_tags_from_udevadm_properties() {
@@ -995,6 +1043,31 @@ mod tests {
     fn fallback_context_explains_functional_non_uaccess_access() {
         assert!(fallback_context(true).contains("device access is currently functional"));
         assert_eq!(fallback_context(false), "");
+    }
+
+    #[test]
+    fn active_zones_detail_reports_daemon_claim_widths() {
+        let config = EdgepadConfig {
+            device: DeviceConfig::Auto,
+            edge_width: 0.20,
+            gestures: vec![
+                GestureBindingConfig {
+                    zone: Zone::Right,
+                    direction: GestureDirection::Up,
+                    action: GestureActionConfig::Log,
+                },
+                GestureBindingConfig {
+                    zone: Zone::Top,
+                    direction: GestureDirection::Left,
+                    action: GestureActionConfig::Log,
+                },
+            ],
+        };
+
+        assert_eq!(
+            active_zones_detail(&config),
+            "active_zones=right,top inactive_zones=left,bottom edge_widths=left=0.000 right=0.200 top=0.200 bottom=0.000"
+        );
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -56,8 +56,57 @@ impl CheckStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DoctorCheck {
     pub status: CheckStatus,
-    pub name: &'static str,
+    pub section: DoctorSection,
+    pub label: &'static str,
     pub detail: String,
+}
+
+impl DoctorCheck {
+    fn new(
+        status: CheckStatus,
+        section: DoctorSection,
+        label: &'static str,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            status,
+            section,
+            label,
+            detail: detail.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoctorSection {
+    Config,
+    Actions,
+    Device,
+    Access,
+    Session,
+    Service,
+}
+
+impl DoctorSection {
+    pub const ALL: [Self; 6] = [
+        Self::Config,
+        Self::Actions,
+        Self::Device,
+        Self::Access,
+        Self::Session,
+        Self::Service,
+    ];
+
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::Config => "Config",
+            Self::Actions => "Actions",
+            Self::Device => "Device",
+            Self::Access => "Access",
+            Self::Session => "Session",
+            Self::Service => "Service",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -135,72 +184,79 @@ fn check_config(config: &DoctorConfig, report: &mut DoctorReport) -> Option<Edge
         None => match default_edgepad_config_path() {
             Ok(path) => path,
             Err(err) => {
-                report.checks.push(DoctorCheck {
-                    status: CheckStatus::Fail,
-                    name: "config path",
-                    detail: err,
-                });
+                report.checks.push(DoctorCheck::new(
+                    CheckStatus::Fail,
+                    DoctorSection::Config,
+                    "path",
+                    err,
+                ));
                 return None;
             }
         },
     };
 
     match fs::metadata(&path) {
-        Ok(metadata) if metadata.is_file() => report.checks.push(DoctorCheck {
-            status: CheckStatus::Ok,
-            name: "config path",
-            detail: format!("{}", path.display()),
-        }),
+        Ok(metadata) if metadata.is_file() => report.checks.push(DoctorCheck::new(
+            CheckStatus::Ok,
+            DoctorSection::Config,
+            "path",
+            format!("{}", path.display()),
+        )),
         Ok(_) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "config path",
-                detail: format!("not a file: {}", path.display()),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Config,
+                "path",
+                format!("not a file: {}", path.display()),
+            ));
             return None;
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "config path",
-                detail: format!(
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Config,
+                "path",
+                format!(
                     "not found: {}; pass --config <file> or create ~/.config/edgepad/edgepad.toml",
                     path.display()
                 ),
-            });
+            ));
             return None;
         }
         Err(err) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "config path",
-                detail: format!("failed to inspect {}: {err}", path.display()),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Config,
+                "path",
+                format!("failed to inspect {}: {err}", path.display()),
+            ));
             return None;
         }
     }
 
     match load_edgepad_config(&path) {
         Ok(edgepad_config) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "config parse",
-                detail: format!(
-                    "device={} edge_width={:.3} gesture_bindings={}",
-                    device_config_label(&edgepad_config.device),
-                    edgepad_config.edge_width,
-                    edgepad_config.gestures.len()
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Config,
+                "file",
+                format!(
+                    "device {}, edge width {}, {}",
+                    device_config_value_label(&edgepad_config.device),
+                    percent_label(edgepad_config.edge_width),
+                    binding_count_label(edgepad_config.gestures.len())
                 ),
-            });
+            ));
             check_gesture_bindings(&edgepad_config, report);
             Some(edgepad_config)
         }
         Err(err) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "config parse",
-                detail: err,
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Config,
+                "file",
+                err,
+            ));
             None
         }
     }
@@ -208,25 +264,27 @@ fn check_config(config: &DoctorConfig, report: &mut DoctorReport) -> Option<Edge
 
 fn check_gesture_bindings(config: &EdgepadConfig, report: &mut DoctorReport) {
     if config.gestures.is_empty() {
-        report.checks.push(DoctorCheck {
-            status: CheckStatus::Fail,
-            name: "gesture bindings",
-            detail: "no gesture bindings configured; add at least one [[gestures]] entry"
-                .to_string(),
-        });
+        report.checks.push(DoctorCheck::new(
+            CheckStatus::Fail,
+            DoctorSection::Config,
+            "bindings",
+            "no gesture bindings configured; add at least one [[gestures]] entry",
+        ));
         return;
     }
 
-    report.checks.push(DoctorCheck {
-        status: CheckStatus::Ok,
-        name: "gesture bindings",
-        detail: format!("{} gesture binding(s) configured", config.gestures.len()),
-    });
-    report.checks.push(DoctorCheck {
-        status: CheckStatus::Ok,
-        name: "active zones",
-        detail: active_zones_detail(config),
-    });
+    report.checks.push(DoctorCheck::new(
+        CheckStatus::Ok,
+        DoctorSection::Config,
+        "bindings",
+        format!("{} configured", binding_count_label(config.gestures.len())),
+    ));
+    report.checks.push(DoctorCheck::new(
+        CheckStatus::Ok,
+        DoctorSection::Config,
+        "zones",
+        active_zones_detail(config),
+    ));
 }
 
 fn active_zones_detail(config: &EdgepadConfig) -> String {
@@ -242,7 +300,7 @@ fn active_zones_detail(config: &EdgepadConfig) -> String {
         .collect();
 
     format!(
-        "active_zones={} inactive_zones={} edge_widths={}",
+        "claiming {}; passthrough {}; widths: {}",
         zone_list_label(&active_zones),
         zone_list_label(&inactive_zones),
         edge_widths_label(config.active_edge_widths())
@@ -262,14 +320,36 @@ fn zone_list_label(zones: &[Zone]) -> String {
         .iter()
         .map(|zone| zone_name(*zone))
         .collect::<Vec<_>>()
-        .join(",")
+        .join(", ")
 }
 
 fn edge_widths_label(widths: EdgeWidths) -> String {
     format!(
-        "left={:.3} right={:.3} top={:.3} bottom={:.3}",
-        widths.left, widths.right, widths.top, widths.bottom
+        "left {}, right {}, top {}, bottom {}",
+        edge_width_label(widths.left),
+        edge_width_label(widths.right),
+        edge_width_label(widths.top),
+        edge_width_label(widths.bottom)
     )
+}
+
+fn edge_width_label(width: f32) -> String {
+    if width <= f32::EPSILON {
+        "off".to_string()
+    } else {
+        percent_label(width)
+    }
+}
+
+fn percent_label(value: f32) -> String {
+    format!("{:.1}%", value * 100.0)
+}
+
+fn binding_count_label(count: usize) -> String {
+    match count {
+        1 => "1 gesture binding".to_string(),
+        _ => format!("{count} gesture bindings"),
+    }
 }
 
 fn check_config_device(
@@ -281,33 +361,36 @@ fn check_config_device(
         (_, Some(device)) => {
             let detail = match loaded_config {
                 Some(config) => format!(
-                    "{} from config overridden by --device {}",
-                    device_config_label(&config.device),
-                    device_config_label(device)
+                    "config device {} overridden by --device {}",
+                    device_config_value_label(&config.device),
+                    device_config_value_label(device)
                 ),
-                None => format!("using --device {}", device_config_label(device)),
+                None => format!("using --device {}", device_config_value_label(device)),
             };
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Warn,
-                name: "config device",
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Warn,
+                DoctorSection::Config,
+                "device",
                 detail,
-            });
+            ));
             device.clone()
         }
         (Some(config), None) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "config device",
-                detail: format!("using {}", device_config_label(&config.device)),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Config,
+                "device",
+                format!("using {}", device_config_value_label(&config.device)),
+            ));
             config.device.clone()
         }
         (None, None) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Warn,
-                name: "config device",
-                detail: "using device=auto because config was not loaded".to_string(),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Warn,
+                DoctorSection::Config,
+                "device",
+                "using auto because config was not loaded",
+            ));
             DeviceConfig::Auto
         }
     }
@@ -319,57 +402,84 @@ fn check_action_executables(config: &EdgepadConfig, report: &mut DoctorReport) {
     }
 
     let mut usages = BTreeMap::<String, Vec<String>>::new();
-    for (index, binding) in config.gestures.iter().enumerate() {
+    for binding in &config.gestures {
         if let GestureActionConfig::Command { argv } = &binding.action {
             if let Some(program) = argv.first() {
                 usages
                     .entry(program.clone())
                     .or_default()
-                    .push(gesture_binding_label(
-                        index,
-                        binding.zone,
-                        binding.direction,
-                    ));
+                    .push(gesture_binding_label(binding.zone, binding.direction));
             }
         }
     }
 
     if usages.is_empty() {
-        report.checks.push(DoctorCheck {
-            status: CheckStatus::Ok,
-            name: "action executable",
-            detail: "no command actions configured".to_string(),
-        });
+        report.checks.push(DoctorCheck::new(
+            CheckStatus::Ok,
+            DoctorSection::Actions,
+            "command",
+            "no command actions configured",
+        ));
         return;
     }
 
-    for (program, bindings) in usages {
+    let mut usages = usages
+        .into_iter()
+        .map(|(program, bindings)| (action_program_name(&program), program, bindings))
+        .collect::<Vec<_>>();
+    usages.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+
+    for (_program_name, program, bindings) in usages {
         let usage = format_binding_usage(&bindings);
         match action_executable_status(&program) {
-            ActionExecutableStatus::Found(path) => report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "action executable",
-                detail: format!("{program} found at {} for {usage}", path.display()),
-            }),
-            ActionExecutableStatus::AbsolutePathExecutable => report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "action executable",
-                detail: format!("{program} is executable for {usage}"),
-            }),
-            ActionExecutableStatus::RelativePathExecutable => report.checks.push(DoctorCheck {
-                status: CheckStatus::Warn,
-                name: "action executable",
-                detail: format!(
-                    "{program} is a relative executable path for {usage}; user services may run from a different directory"
+            ActionExecutableStatus::Found(path) => report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Actions,
+                "command",
+                action_ok_detail(&program, &usage, &path),
+            )),
+            ActionExecutableStatus::AbsolutePathExecutable => report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Actions,
+                "command",
+                action_ok_detail(&program, &usage, Path::new(&program)),
+            )),
+            ActionExecutableStatus::RelativePathExecutable => report.checks.push(DoctorCheck::new(
+                CheckStatus::Warn,
+                DoctorSection::Actions,
+                "command",
+                format!(
+                    "{}: {usage}\npath: {program}\nwarning: relative executable paths may not work from a user service",
+                    action_program_name(&program)
                 ),
-            }),
-            ActionExecutableStatus::Missing(message) => report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "action executable",
-                detail: format!("{message} for {usage}"),
-            }),
+            )),
+            ActionExecutableStatus::Missing(message) => report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Actions,
+                "command",
+                format!(
+                    "{}: {usage}\nproblem: {message}",
+                    action_program_name(&program)
+                ),
+            )),
         }
     }
+}
+
+fn action_ok_detail(program: &str, usage: &str, path: &Path) -> String {
+    format!(
+        "{}: {usage}\npath: {}",
+        action_program_name(program),
+        path.display()
+    )
+}
+
+fn action_program_name(program: &str) -> String {
+    Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program)
+        .to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -427,24 +537,20 @@ fn find_executable_in_path(program: &str, path_env: Option<OsString>) -> Option<
 
 fn format_binding_usage(bindings: &[String]) -> String {
     match bindings {
-        [] => "0 binding(s)".to_string(),
-        [binding] => binding.clone(),
-        _ => format!("{} binding(s): {}", bindings.len(), bindings.join(", ")),
+        [] => "0 bindings".to_string(),
+        [binding] => format!("1 binding ({binding})"),
+        _ => format!("{} bindings ({})", bindings.len(), bindings.join(", ")),
     }
 }
 
-fn gesture_binding_label(index: usize, zone: Zone, direction: GestureDirection) -> String {
-    format!(
-        "gestures[{index}] {}.{}",
-        zone_name(zone),
-        direction_name(direction)
-    )
+fn gesture_binding_label(zone: Zone, direction: GestureDirection) -> String {
+    format!("{}.{}", zone_name(zone), direction_name(direction))
 }
 
-fn device_config_label(device: &DeviceConfig) -> String {
+fn device_config_value_label(device: &DeviceConfig) -> String {
     match device {
-        DeviceConfig::Auto => "device=auto".to_string(),
-        DeviceConfig::Path(path) => format!("device={}", path.display()),
+        DeviceConfig::Auto => "auto".to_string(),
+        DeviceConfig::Path(path) => format!("{}", path.display()),
     }
 }
 
@@ -455,57 +561,62 @@ fn check_touchpad_selection(
 ) -> Option<PathBuf> {
     match device {
         DeviceConfig::Path(path) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Warn,
-                name: "touchpad auto-detect",
-                detail: format!(
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Warn,
+                DoctorSection::Device,
+                "touchpad",
+                format!(
                     "skipped because explicit device was provided: {}",
                     path.display()
                 ),
-            });
+            ));
             Some(path.clone())
         }
         DeviceConfig::Auto => match discover_device_report(input_root) {
             Ok(discovery) if discovery.event_node_count == 0 => {
-                report.checks.push(DoctorCheck {
-                    status: CheckStatus::Fail,
-                    name: "touchpad auto-detect",
-                    detail: format!("no event devices found under {}", input_root.display()),
-                });
+                report.checks.push(DoctorCheck::new(
+                    CheckStatus::Fail,
+                    DoctorSection::Device,
+                    "touchpad",
+                    format!("no event devices found under {}", input_root.display()),
+                ));
                 None
             }
             Ok(discovery) if discovery.summaries.is_empty() => {
-                report.checks.push(DoctorCheck {
-                    status: CheckStatus::Fail,
-                    name: "touchpad auto-detect",
-                    detail: format!(
+                report.checks.push(DoctorCheck::new(
+                    CheckStatus::Fail,
+                    DoctorSection::Device,
+                    "touchpad",
+                    format!(
                         "{} event node(s) found under {}, but none were readable",
                         discovery.event_node_count,
                         input_root.display()
                     ),
-                });
+                ));
                 None
             }
             Ok(discovery) => {
                 let candidates = touchpad_candidates(&discovery.summaries);
                 match candidates.as_slice() {
                     [] => {
-                        report.checks.push(DoctorCheck {
-                            status: CheckStatus::Fail,
-                            name: "touchpad auto-detect",
-                            detail: format!(
+                        report.checks.push(DoctorCheck::new(
+                            CheckStatus::Fail,
+                            DoctorSection::Device,
+                            "touchpad",
+                            format!(
                                 "no touchpad candidates among {} readable event device(s)",
                                 discovery.summaries.len()
                             ),
-                        });
+                        ));
                         None
                     }
                     [candidate] => {
-                        report.checks.push(DoctorCheck {
-                            status: CheckStatus::Ok,
-                            name: "touchpad auto-detect",
-                            detail: format_device_line(candidate),
-                        });
+                        report.checks.push(DoctorCheck::new(
+                            CheckStatus::Ok,
+                            DoctorSection::Device,
+                            "touchpad",
+                            format_device_line(candidate),
+                        ));
                         Some(candidate.path.clone())
                     }
                     _ => {
@@ -514,23 +625,25 @@ fn check_touchpad_selection(
                             .map(|candidate| candidate.path.display().to_string())
                             .collect::<Vec<_>>()
                             .join(", ");
-                        report.checks.push(DoctorCheck {
-                            status: CheckStatus::Fail,
-                            name: "touchpad auto-detect",
-                            detail: format!(
+                        report.checks.push(DoctorCheck::new(
+                            CheckStatus::Fail,
+                            DoctorSection::Device,
+                            "touchpad",
+                            format!(
                                 "multiple touchpad candidates found; pass --device explicitly: {devices}"
                             ),
-                        });
+                        ));
                         None
                     }
                 }
             }
             Err(err) => {
-                report.checks.push(DoctorCheck {
-                    status: CheckStatus::Fail,
-                    name: "touchpad auto-detect",
-                    detail: format!("failed to list {}: {err}", input_root.display()),
-                });
+                report.checks.push(DoctorCheck::new(
+                    CheckStatus::Fail,
+                    DoctorSection::Device,
+                    "touchpad",
+                    format!("failed to list {}: {err}", input_root.display()),
+                ));
                 None
             }
         },
@@ -539,29 +652,32 @@ fn check_touchpad_selection(
 
 fn check_touchpad_readable(path: Option<&Path>, report: &mut DoctorReport) -> bool {
     let Some(path) = path else {
-        report.checks.push(DoctorCheck {
-            status: CheckStatus::Fail,
-            name: "touchpad readable",
-            detail: "skipped because no touchpad event node is selected".to_string(),
-        });
+        report.checks.push(DoctorCheck::new(
+            CheckStatus::Fail,
+            DoctorSection::Device,
+            "input",
+            "skipped because no touchpad event node is selected",
+        ));
         return false;
     };
 
     match Device::open(path) {
         Ok(_) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "touchpad readable",
-                detail: format!("{} can be opened by current user", path.display()),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Device,
+                "input",
+                format!("{} can be opened by current user", path.display()),
+            ));
             true
         }
         Err(err) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "touchpad readable",
-                detail: format!("failed to open {}: {err}", path.display()),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Device,
+                "input",
+                format!("failed to open {}: {err}", path.display()),
+            ));
             false
         }
     }
@@ -570,30 +686,33 @@ fn check_touchpad_readable(path: Option<&Path>, report: &mut DoctorReport) -> bo
 fn check_uinput(path: &Path, report: &mut DoctorReport) -> bool {
     match OpenOptions::new().read(true).write(true).open(path) {
         Ok(_) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "/dev/uinput",
-                detail: format!("{} is readable and writable", path.display()),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Device,
+                "uinput",
+                format!("{} is readable and writable", path.display()),
+            ));
             true
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "/dev/uinput",
-                detail: format!(
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Device,
+                "uinput",
+                format!(
                     "{} is missing; load the uinput kernel module",
                     path.display()
                 ),
-            });
+            ));
             false
         }
         Err(err) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "/dev/uinput",
-                detail: format!("failed to open {} read/write: {err}", path.display()),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Device,
+                "uinput",
+                format!("failed to open {} read/write: {err}", path.display()),
+            ));
             false
         }
     }
@@ -606,11 +725,12 @@ fn check_uaccess_tags(
     report: &mut DoctorReport,
 ) {
     let Some(touchpad_path) = touchpad_path else {
-        report.checks.push(DoctorCheck {
-            status: CheckStatus::Fail,
-            name: "uaccess tags",
-            detail: "skipped because no touchpad event node is selected".to_string(),
-        });
+        report.checks.push(DoctorCheck::new(
+            CheckStatus::Fail,
+            DoctorSection::Access,
+            "udev tags",
+            "skipped because no touchpad event node is selected",
+        ));
         return;
     };
 
@@ -624,32 +744,35 @@ fn check_uaccess_tags(
                 && has_tag(&uinput_tags, "uaccess")
                 && has_tag(&uinput_tags, "seat") =>
         {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "uaccess tags",
-                detail: format!(
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Access,
+                "udev tags",
+                format!(
                     "{} and {} have current udev tags seat,uaccess",
                     touchpad_path.display(),
                     uinput_path.display()
                 ),
-            });
+            ));
         }
         (Ok(touchpad_tags), Ok(uinput_tags)) => {
-            report.checks.push(DoctorCheck {
-                status: fallback_sensitive_status(device_access_ok),
-                name: "uaccess tags",
-                detail: format!(
+            report.checks.push(DoctorCheck::new(
+                access_model_gap_status(device_access_ok),
+                DoctorSection::Access,
+                "udev tags",
+                format!(
                     "missing seat/uaccess current tags; touchpad={touchpad_tags:?} uinput={uinput_tags:?}{}",
-                    fallback_context(device_access_ok),
+                    access_model_gap_note(device_access_ok),
                 ),
-            });
+            ));
         }
         (Err(err), _) | (_, Err(err)) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "uaccess tags",
-                detail: err,
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Access,
+                "udev tags",
+                err,
+            ));
         }
     }
 }
@@ -682,21 +805,23 @@ fn check_uaccess_acl(
     report: &mut DoctorReport,
 ) {
     let Some(touchpad_path) = touchpad_path else {
-        report.checks.push(DoctorCheck {
-            status: CheckStatus::Fail,
-            name: "uaccess ACL",
-            detail: "skipped because no touchpad event node is selected".to_string(),
-        });
+        report.checks.push(DoctorCheck::new(
+            CheckStatus::Fail,
+            DoctorSection::Access,
+            "acl",
+            "skipped because no touchpad event node is selected",
+        ));
         return;
     };
 
     let username = current_username();
     let Some(username) = username else {
-        report.checks.push(DoctorCheck {
-            status: CheckStatus::Warn,
-            name: "uaccess ACL",
-            detail: "could not determine current username for ACL inspection".to_string(),
-        });
+        report.checks.push(DoctorCheck::new(
+            CheckStatus::Warn,
+            DoctorSection::Access,
+            "acl",
+            "could not determine current username for ACL inspection",
+        ));
         return;
     };
 
@@ -704,28 +829,31 @@ fn check_uaccess_acl(
     let uinput_acl = getfacl_grants_user(uinput_path, &username);
 
     match (touchpad_acl, uinput_acl) {
-        (Ok(true), Ok(true)) => report.checks.push(DoctorCheck {
-            status: CheckStatus::Ok,
-            name: "uaccess ACL",
-            detail: format!(
+        (Ok(true), Ok(true)) => report.checks.push(DoctorCheck::new(
+            CheckStatus::Ok,
+            DoctorSection::Access,
+            "acl",
+            format!(
                 "user {username} has rw ACL on {} and {}",
                 touchpad_path.display(),
                 uinput_path.display()
             ),
-        }),
-        (Ok(touchpad_ok), Ok(uinput_ok)) => report.checks.push(DoctorCheck {
-            status: fallback_sensitive_status(device_access_ok),
-            name: "uaccess ACL",
-            detail: format!(
+        )),
+        (Ok(touchpad_ok), Ok(uinput_ok)) => report.checks.push(DoctorCheck::new(
+            access_model_gap_status(device_access_ok),
+            DoctorSection::Access,
+            "acl",
+            format!(
                 "missing rw ACL for user {username}; touchpad_acl={touchpad_ok} uinput_acl={uinput_ok}{}",
-                fallback_context(device_access_ok),
+                access_model_gap_note(device_access_ok),
             ),
-        }),
-        (Err(err), _) | (_, Err(err)) => report.checks.push(DoctorCheck {
-            status: CheckStatus::Warn,
-            name: "uaccess ACL",
-            detail: err,
-        }),
+        )),
+        (Err(err), _) | (_, Err(err)) => report.checks.push(DoctorCheck::new(
+            CheckStatus::Warn,
+            DoctorSection::Access,
+            "acl",
+            err,
+        )),
     }
 }
 
@@ -762,38 +890,42 @@ fn check_logind_seat(device_access_ok: bool, report: &mut DoctorReport) {
                 && output.stdout.contains("State: active")
                 && output.stdout.contains("Seat: seat") =>
         {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "logind seat",
-                detail: "current session is active on a local seat".to_string(),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Session,
+                "seat",
+                "current session is active on a local seat",
+            ));
         }
-        Ok(output) if output.status_success => report.checks.push(DoctorCheck {
-            status: fallback_sensitive_status(device_access_ok),
-            name: "logind seat",
-            detail: format!(
+        Ok(output) if output.status_success => report.checks.push(DoctorCheck::new(
+            access_model_gap_status(device_access_ok),
+            DoctorSection::Session,
+            "seat",
+            format!(
                 "current loginctl session is not active on a local seat{}",
-                fallback_context(device_access_ok)
+                access_model_gap_note(device_access_ok)
             ),
-        }),
-        Ok(output) => report.checks.push(DoctorCheck {
-            status: fallback_sensitive_status(device_access_ok),
-            name: "logind seat",
-            detail: format!(
+        )),
+        Ok(output) => report.checks.push(DoctorCheck::new(
+            access_model_gap_status(device_access_ok),
+            DoctorSection::Session,
+            "seat",
+            format!(
                 "loginctl session-status failed: {}{}",
                 output.stderr_or_stdout(),
-                fallback_context(device_access_ok)
+                access_model_gap_note(device_access_ok)
             ),
-        }),
-        Err(err) => report.checks.push(DoctorCheck {
-            status: fallback_sensitive_status(device_access_ok),
-            name: "logind seat",
-            detail: format!("{err}{}", fallback_context(device_access_ok)),
-        }),
+        )),
+        Err(err) => report.checks.push(DoctorCheck::new(
+            access_model_gap_status(device_access_ok),
+            DoctorSection::Session,
+            "seat",
+            format!("{err}{}", access_model_gap_note(device_access_ok)),
+        )),
     }
 }
 
-fn fallback_sensitive_status(device_access_ok: bool) -> CheckStatus {
+fn access_model_gap_status(device_access_ok: bool) -> CheckStatus {
     if device_access_ok {
         CheckStatus::Warn
     } else {
@@ -801,9 +933,9 @@ fn fallback_sensitive_status(device_access_ok: bool) -> CheckStatus {
     }
 }
 
-fn fallback_context(device_access_ok: bool) -> &'static str {
+fn access_model_gap_note(device_access_ok: bool) -> &'static str {
     if device_access_ok {
-        "; device access is currently functional, so group or broader filesystem permissions may be masking this"
+        "; device access is currently functional through another access model"
     } else {
         ""
     }
@@ -812,27 +944,30 @@ fn fallback_context(device_access_ok: bool) -> &'static str {
 fn check_systemd_user(report: &mut DoctorReport) -> bool {
     match command_output("systemctl", &["--user", "show-environment"]) {
         Ok(output) if output.status_success => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Ok,
-                name: "systemd user",
-                detail: "systemctl --user is available".to_string(),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Ok,
+                DoctorSection::Session,
+                "systemd",
+                "systemctl --user is available",
+            ));
             true
         }
         Ok(output) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "systemd user",
-                detail: format!("systemctl --user failed: {}", output.stderr_or_stdout()),
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Session,
+                "systemd",
+                format!("systemctl --user failed: {}", output.stderr_or_stdout()),
+            ));
             false
         }
         Err(err) => {
-            report.checks.push(DoctorCheck {
-                status: CheckStatus::Fail,
-                name: "systemd user",
-                detail: err,
-            });
+            report.checks.push(DoctorCheck::new(
+                CheckStatus::Fail,
+                DoctorSection::Session,
+                "systemd",
+                err,
+            ));
             false
         }
     }
@@ -844,11 +979,12 @@ fn check_service_status(
     report: &mut DoctorReport,
 ) {
     if !systemd_user_available {
-        report.checks.push(DoctorCheck {
-            status: CheckStatus::Warn,
-            name: "edgepad service",
-            detail: "skipped because systemctl --user is not available".to_string(),
-        });
+        report.checks.push(DoctorCheck::new(
+            CheckStatus::Warn,
+            DoctorSection::Service,
+            "unit",
+            "skipped because systemctl --user is not available",
+        ));
         return;
     }
 
@@ -873,44 +1009,52 @@ fn check_service_status(
             let active_state = property_value(&output.stdout, "ActiveState").unwrap_or("unknown");
             let sub_state = property_value(&output.stdout, "SubState").unwrap_or("unknown");
             if load_state == "not-found" {
-                report.checks.push(DoctorCheck {
-                    status: CheckStatus::Warn,
-                    name: "edgepad service",
-                    detail: format!("{service_name} is not installed in the user manager"),
-                });
+                report.checks.push(DoctorCheck::new(
+                    CheckStatus::Warn,
+                    DoctorSection::Service,
+                    "unit",
+                    format!("{service_name} is not installed in the user manager"),
+                ));
             } else if active_state == "active" {
-                report.checks.push(DoctorCheck {
-                    status: CheckStatus::Ok,
-                    name: "edgepad service",
-                    detail: format!("{service_name} is active ({sub_state})"),
-                });
+                report.checks.push(DoctorCheck::new(
+                    CheckStatus::Ok,
+                    DoctorSection::Service,
+                    "unit",
+                    format!("{service_name} is active ({sub_state})"),
+                ));
             } else if active_state == "failed" {
-                report.checks.push(DoctorCheck {
-                    status: CheckStatus::Fail,
-                    name: "edgepad service",
-                    detail: format!("{service_name} is failed ({sub_state})"),
-                });
+                report.checks.push(DoctorCheck::new(
+                    CheckStatus::Fail,
+                    DoctorSection::Service,
+                    "unit",
+                    format!("{service_name} is failed ({sub_state})"),
+                ));
             } else {
-                report.checks.push(DoctorCheck {
-                    status: CheckStatus::Warn,
-                    name: "edgepad service",
-                    detail: format!("{service_name} is loaded={load_state} active={active_state} sub={sub_state}"),
-                });
+                report.checks.push(DoctorCheck::new(
+                    CheckStatus::Warn,
+                    DoctorSection::Service,
+                    "unit",
+                    format!(
+                        "{service_name} is loaded={load_state} active={active_state} sub={sub_state}"
+                    ),
+                ));
             }
         }
-        Ok(output) => report.checks.push(DoctorCheck {
-            status: CheckStatus::Warn,
-            name: "edgepad service",
-            detail: format!(
+        Ok(output) => report.checks.push(DoctorCheck::new(
+            CheckStatus::Warn,
+            DoctorSection::Service,
+            "unit",
+            format!(
                 "could not inspect {service_name}: {}",
                 output.stderr_or_stdout()
             ),
-        }),
-        Err(err) => report.checks.push(DoctorCheck {
-            status: CheckStatus::Warn,
-            name: "edgepad service",
-            detail: err,
-        }),
+        )),
+        Err(err) => report.checks.push(DoctorCheck::new(
+            CheckStatus::Warn,
+            DoctorSection::Service,
+            "unit",
+            err,
+        )),
     }
 }
 
@@ -1015,7 +1159,7 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_static_tags_when_current_tags_are_absent() {
+    fn uses_static_tags_when_current_tags_are_absent() {
         let tags = parse_udev_current_tags("DEVNAME=/dev/uinput\nTAGS=:seat:uaccess:\n");
 
         assert_eq!(tags, vec!["seat", "uaccess"]);
@@ -1034,15 +1178,15 @@ mod tests {
     }
 
     #[test]
-    fn fallback_sensitive_status_warns_when_device_access_is_functional() {
-        assert_eq!(fallback_sensitive_status(true), CheckStatus::Warn);
-        assert_eq!(fallback_sensitive_status(false), CheckStatus::Fail);
+    fn access_model_gap_status_warns_when_device_access_is_functional() {
+        assert_eq!(access_model_gap_status(true), CheckStatus::Warn);
+        assert_eq!(access_model_gap_status(false), CheckStatus::Fail);
     }
 
     #[test]
-    fn fallback_context_explains_functional_non_uaccess_access() {
-        assert!(fallback_context(true).contains("device access is currently functional"));
-        assert_eq!(fallback_context(false), "");
+    fn access_model_gap_note_explains_functional_non_uaccess_access() {
+        assert!(access_model_gap_note(true).contains("another access model"));
+        assert_eq!(access_model_gap_note(false), "");
     }
 
     #[test]
@@ -1066,7 +1210,7 @@ mod tests {
 
         assert_eq!(
             active_zones_detail(&config),
-            "active_zones=right,top inactive_zones=left,bottom edge_widths=left=0.000 right=0.200 top=0.200 bottom=0.000"
+            "claiming right, top; passthrough left, bottom; widths: left off, right 20.0%, top 20.0%, bottom off"
         );
     }
 
@@ -1132,7 +1276,7 @@ mod tests {
         assert_eq!(report.checks.len(), 1);
         assert_eq!(report.checks[0].status, CheckStatus::Fail);
         assert!(report.checks[0].detail.contains("not found"));
-        assert!(report.checks[0].detail.contains("gestures[0] right.up"));
+        assert!(report.checks[0].detail.contains("right.up"));
     }
 
     #[test]
@@ -1161,21 +1305,9 @@ mod tests {
     fn report_counts_failures_warnings_and_successes() {
         let report = DoctorReport {
             checks: vec![
-                DoctorCheck {
-                    status: CheckStatus::Ok,
-                    name: "a",
-                    detail: String::new(),
-                },
-                DoctorCheck {
-                    status: CheckStatus::Warn,
-                    name: "b",
-                    detail: String::new(),
-                },
-                DoctorCheck {
-                    status: CheckStatus::Fail,
-                    name: "c",
-                    detail: String::new(),
-                },
+                DoctorCheck::new(CheckStatus::Ok, DoctorSection::Config, "a", ""),
+                DoctorCheck::new(CheckStatus::Warn, DoctorSection::Config, "b", ""),
+                DoctorCheck::new(CheckStatus::Fail, DoctorSection::Config, "c", ""),
             ],
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod doctor;
 pub mod dump;
 pub mod proxy;
 pub mod raw;
+pub mod status;
 pub mod uinput;
 
 pub mod core {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,15 +27,17 @@ use edgepad::raw::{
     RecordingRawOutputSink,
 };
 use edgepad::replay::{parse_replay_file, replay_stats, run_frames};
+use edgepad::status::{run_status, StatusConfig, StatusReport};
 use evdev::raw_stream::RawDevice;
 
-const USAGE: &str = "usage: edgepad replay <fixture.ev> | edgepad replay-raw <raw.ev> | edgepad devices [--root <input-root>] [--all] | edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>] | edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw] | edgepad proxy --device <event-node> --frames N (--dry-run | --uinput --grab) [--edge-width F] | edgepad daemon [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F]";
+const USAGE: &str = "usage: edgepad replay <fixture.ev> | edgepad replay-raw <raw.ev> | edgepad devices [--root <input-root>] [--all] | edgepad status [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--service <unit>] | edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>] | edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw] | edgepad proxy --device <event-node> --frames N (--dry-run | --uinput --grab) [--edge-width F] | edgepad daemon [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F]";
 const HELP: &str = "\
 Usage:
   edgepad <command> [options]
 
 Commands:
   devices     List readable input devices and touchpad candidates
+  status      Show a short daemon/config/device summary
   doctor      Check runtime prerequisites and service health
   daemon      Run the live edge-gesture proxy
   dump        Capture touchpad events into a replay fixture
@@ -120,6 +122,18 @@ Options:
       --uinput <path>             uinput device path [default: /dev/uinput]
       --service <unit>            systemd user unit to inspect [default: edgepad.service]
 ";
+const STATUS_USAGE: &str = "usage: edgepad status [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--service <unit>]";
+const STATUS_HELP: &str = "\
+Usage:
+  edgepad status [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--service <unit>]
+
+Options:
+      --config <file>             TOML config path
+                                  [default: $XDG_CONFIG_HOME/edgepad/edgepad.toml or ~/.config/edgepad/edgepad.toml]
+      --device auto|<event-node>  Override touchpad device selection from config
+      --input-root <input-root>   Input device directory for auto-detect [default: /dev/input]
+      --service <unit>            systemd user unit to inspect [default: edgepad.service]
+";
 const DAEMON_IDLE_DRAIN_TIMEOUT: Duration = Duration::from_millis(1000);
 const DAEMON_SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const DAEMON_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -194,6 +208,15 @@ fn run() -> Result<i32, String> {
             }
             let config = parse_doctor_args(args.into_iter())?;
             doctor(&config)
+        }
+        Some("status") => {
+            let args = args.collect::<Vec<_>>();
+            if is_help_request(&args) {
+                print_help(STATUS_HELP);
+                return Ok(0);
+            }
+            let config = parse_status_args(args.into_iter())?;
+            status(&config)
         }
         Some("dump") => {
             let args = args.collect::<Vec<_>>();
@@ -302,6 +325,35 @@ fn parse_doctor_args(mut args: impl Iterator<Item = String>) -> Result<DoctorCon
                 return Err(format!("unknown doctor option {other}"));
             }
             _ => return Err(DOCTOR_USAGE.to_string()),
+        }
+    }
+
+    Ok(config)
+}
+
+fn parse_status_args(mut args: impl Iterator<Item = String>) -> Result<StatusConfig, String> {
+    let mut config = StatusConfig::default();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--config" => {
+                config.config_path =
+                    Some(args.next().ok_or_else(|| STATUS_USAGE.to_string())?.into());
+            }
+            "--device" => {
+                let raw_value = args.next().ok_or_else(|| STATUS_USAGE.to_string())?;
+                config.device_override = Some(DeviceConfig::parse(&raw_value)?);
+            }
+            "--input-root" => {
+                config.input_root = args.next().ok_or_else(|| STATUS_USAGE.to_string())?.into();
+            }
+            "--service" => {
+                config.service_name = args.next().ok_or_else(|| STATUS_USAGE.to_string())?;
+            }
+            other if other.starts_with('-') => {
+                return Err(format!("unknown status option {other}"));
+            }
+            _ => return Err(STATUS_USAGE.to_string()),
         }
     }
 
@@ -526,6 +578,24 @@ fn doctor(config: &DoctorConfig) -> Result<i32, String> {
     } else {
         Ok(0)
     }
+}
+
+fn status(config: &StatusConfig) -> Result<i32, String> {
+    let report = run_status(config);
+    print_status_report(&report);
+    Ok(report.result.exit_code())
+}
+
+fn print_status_report(report: &StatusReport) {
+    println!("edgepad status");
+    println!();
+
+    for line in &report.lines {
+        println!("{:<8} {}", line.subject.label(), line.detail);
+    }
+
+    println!();
+    println!("{:<8} {}", "Result", report.result.label());
 }
 
 fn print_doctor_report(report: &DoctorReport) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -740,11 +740,12 @@ fn run_daemon_proxy_with_startup_retry(
         }
 
         let run_result = config.device.resolve(input_root).and_then(|device_path| {
+            let edge_widths = config.active_edge_widths();
             if last_announced_device.as_ref() != Some(&device_path) {
                 eprintln!(
-                    "edgepad daemon: device={} edge_width={:.3} gesture_bindings={}",
+                    "edgepad daemon: device={} edge_widths={} gesture_bindings={}",
                     device_path.display(),
-                    config.edge_width,
+                    edge_widths_label(edge_widths),
                     config.gestures.len()
                 );
                 last_announced_device = Some(device_path.clone());
@@ -757,7 +758,7 @@ fn run_daemon_proxy_with_startup_retry(
                         stop: stop.clone(),
                         idle_drain_timeout: DAEMON_IDLE_DRAIN_TIMEOUT,
                     },
-                    edge_widths: EdgeWidths::all(config.edge_width),
+                    edge_widths,
                     mode: ProxyMode::UinputGrab,
                 },
                 action_dispatcher,
@@ -898,7 +899,7 @@ fn print_proxy_summary(summary: &ProxyRunSummary) {
     if let Some(requested_frame_boundaries) = summary.requested_frame_boundaries {
         println!("requested_frame_boundaries: {requested_frame_boundaries}");
     }
-    println!("edge_width: {:.3}", summary.edge_widths.left);
+    println!("edge_widths: {}", edge_widths_label(summary.edge_widths));
     let stats = &summary.stats;
     println!("input_frame_boundaries: {}", stats.input_frame_boundaries);
     println!("raw_frames: {}", stats.raw_frames);
@@ -956,6 +957,13 @@ fn default_capabilities() -> Capabilities {
         x: AxisRange { min: 0, max: 1000 },
         y: AxisRange { min: 0, max: 700 },
     }
+}
+
+fn edge_widths_label(widths: EdgeWidths) -> String {
+    format!(
+        "left={:.3} right={:.3} top={:.3} bottom={:.3}",
+        widths.left, widths.right, widths.top, widths.bottom
+    )
 }
 
 fn replay(path: &Path) -> Result<(), String> {
@@ -1167,6 +1175,19 @@ mod tests {
         assert_eq!(
             dump_next_command(DumpFormat::Replay, Path::new("bug.ev")),
             "edgepad replay bug.ev"
+        );
+    }
+
+    #[test]
+    fn edge_widths_label_prints_all_zones() {
+        assert_eq!(
+            edge_widths_label(EdgeWidths {
+                left: 0.0,
+                right: 0.1,
+                top: 0.2,
+                bottom: 0.3,
+            }),
+            "left=0.000 right=0.100 top=0.200 bottom=0.300"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use edgepad::config::{
 };
 use edgepad::core::{AxisRange, Capabilities, EdgeWidths, Engine, GestureDirection, Zone};
 use edgepad::device::{discover_device_report, format_device_line, touchpad_candidates};
-use edgepad::doctor::{run_doctor, DoctorConfig, DoctorReport};
+use edgepad::doctor::{run_doctor, DoctorCheck, DoctorConfig, DoctorReport, DoctorSection};
 use edgepad::dump::{
     capabilities_from_raw_device, write_capture_header, write_fixture_events_with_limit,
     write_raw_events_with_limit, WriteEventsResult,
@@ -530,22 +530,56 @@ fn doctor(config: &DoctorConfig) -> Result<i32, String> {
 
 fn print_doctor_report(report: &DoctorReport) {
     println!("edgepad doctor");
-    for check in &report.checks {
-        println!(
-            "{:<4} {:<22} {}",
-            check.status.label(),
-            check.name,
-            check.detail
-        );
+
+    for section in DoctorSection::ALL {
+        let checks = report
+            .checks
+            .iter()
+            .filter(|check| check.section == section)
+            .collect::<Vec<_>>();
+        if checks.is_empty() {
+            continue;
+        }
+
+        println!();
+        println!("{}", section.title());
+        for check in checks {
+            print_doctor_check(check);
+        }
     }
+
     let counts = report.counts();
+    println!();
+    println!("Summary");
     println!(
-        "summary: ok={} warn={} fail={}",
+        "  ok={} warn={} fail={}",
         counts.ok, counts.warn, counts.fail
     );
-    match report.has_failures() {
-        true => println!("result: problems found"),
-        false => println!("result: ok"),
+    println!("  result: {}", doctor_result_label(report));
+}
+
+fn print_doctor_check(check: &DoctorCheck) {
+    let mut detail_lines = check.detail.lines();
+    let first_detail = detail_lines.next().unwrap_or("");
+    println!(
+        "  {:<5} {:<10} {}",
+        check.status.label(),
+        check.label,
+        first_detail
+    );
+    for line in detail_lines {
+        println!("  {:<5} {:<10} {}", "", "", line);
+    }
+}
+
+fn doctor_result_label(report: &DoctorReport) -> &'static str {
+    let counts = report.counts();
+    if counts.fail > 0 {
+        "problems found"
+    } else if counts.warn > 0 {
+        "usable with warnings"
+    } else {
+        "ready"
     }
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,562 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use evdev::Device;
+
+use crate::config::{
+    default_edgepad_config_path, load_edgepad_config, DeviceConfig, EdgepadConfig,
+};
+use crate::core::{EdgeWidths, Zone};
+use crate::device::{discover_device_report, format_device_line, touchpad_candidates};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusConfig {
+    pub config_path: Option<PathBuf>,
+    pub device_override: Option<DeviceConfig>,
+    pub input_root: PathBuf,
+    pub service_name: String,
+}
+
+impl Default for StatusConfig {
+    fn default() -> Self {
+        Self {
+            config_path: None,
+            device_override: None,
+            input_root: PathBuf::from("/dev/input"),
+            service_name: "edgepad.service".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusSeverity {
+    Ok,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusSubject {
+    Service,
+    Config,
+    Device,
+    Zones,
+    Actions,
+}
+
+impl StatusSubject {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Service => "Service",
+            Self::Config => "Config",
+            Self::Device => "Device",
+            Self::Zones => "Zones",
+            Self::Actions => "Actions",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusLine {
+    pub severity: StatusSeverity,
+    pub subject: StatusSubject,
+    pub detail: String,
+}
+
+impl StatusLine {
+    fn ok(subject: StatusSubject, detail: impl Into<String>) -> Self {
+        Self {
+            severity: StatusSeverity::Ok,
+            subject,
+            detail: detail.into(),
+        }
+    }
+
+    fn warn(subject: StatusSubject, detail: impl Into<String>) -> Self {
+        Self {
+            severity: StatusSeverity::Warn,
+            subject,
+            detail: detail.into(),
+        }
+    }
+
+    fn fail(subject: StatusSubject, detail: impl Into<String>) -> Self {
+        Self {
+            severity: StatusSeverity::Fail,
+            subject,
+            detail: detail.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusResult {
+    Running,
+    NeedsAttention,
+    NotRunning,
+    Misconfigured,
+}
+
+impl StatusResult {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::NeedsAttention => "needs attention",
+            Self::NotRunning => "not running",
+            Self::Misconfigured => "misconfigured",
+        }
+    }
+
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::Running | Self::NeedsAttention => 0,
+            Self::NotRunning | Self::Misconfigured => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusReport {
+    pub lines: Vec<StatusLine>,
+    pub result: StatusResult,
+}
+
+pub fn run_status(config: &StatusConfig) -> StatusReport {
+    let mut lines = vec![service_status_line(&config.service_name)];
+
+    match load_status_config(config) {
+        Ok((config_path, edgepad_config)) => {
+            lines.push(StatusLine::ok(
+                StatusSubject::Config,
+                config_path.display().to_string(),
+            ));
+            lines.push(device_status_line(
+                &edgepad_config.device,
+                &config.input_root,
+            ));
+            lines.push(zones_status_line(&edgepad_config));
+            lines.push(actions_status_line(&edgepad_config));
+        }
+        Err(err) => {
+            lines.push(StatusLine::fail(StatusSubject::Config, err));
+        }
+    }
+
+    let result = status_result(&lines);
+    StatusReport { lines, result }
+}
+
+fn load_status_config(config: &StatusConfig) -> Result<(PathBuf, EdgepadConfig), String> {
+    let config_path = match &config.config_path {
+        Some(path) => path.clone(),
+        None => default_edgepad_config_path()?,
+    };
+
+    match fs::metadata(&config_path) {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => return Err(format!("not a file: {}", config_path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(format!("not found: {}", config_path.display()));
+        }
+        Err(err) => {
+            return Err(format!(
+                "failed to inspect {}: {err}",
+                config_path.display()
+            ))
+        }
+    }
+
+    let mut edgepad_config = load_edgepad_config(&config_path)?;
+    if let Some(device) = &config.device_override {
+        edgepad_config.device = device.clone();
+    }
+
+    Ok((config_path, edgepad_config))
+}
+
+fn device_status_line(device: &DeviceConfig, input_root: &Path) -> StatusLine {
+    match device {
+        DeviceConfig::Path(path) => explicit_device_status_line(path),
+        DeviceConfig::Auto => auto_device_status_line(input_root),
+    }
+}
+
+fn explicit_device_status_line(path: &Path) -> StatusLine {
+    match Device::open(path) {
+        Ok(device) => StatusLine::ok(
+            StatusSubject::Device,
+            format!(
+                "{} {}",
+                path.display(),
+                device.name().unwrap_or("unknown touchpad")
+            ),
+        ),
+        Err(err) => StatusLine::fail(
+            StatusSubject::Device,
+            format!(
+                "configured path cannot be opened: {} ({err})",
+                path.display()
+            ),
+        ),
+    }
+}
+
+fn auto_device_status_line(input_root: &Path) -> StatusLine {
+    match discover_device_report(input_root) {
+        Ok(discovery) if discovery.event_node_count == 0 => StatusLine::fail(
+            StatusSubject::Device,
+            format!(
+                "auto failed: no event devices under {}",
+                input_root.display()
+            ),
+        ),
+        Ok(discovery) if discovery.summaries.is_empty() => StatusLine::fail(
+            StatusSubject::Device,
+            format!(
+                "auto failed: {} event device(s) found under {}, but none were readable",
+                discovery.event_node_count,
+                input_root.display()
+            ),
+        ),
+        Ok(discovery) => match touchpad_candidates(&discovery.summaries).as_slice() {
+            [] => StatusLine::fail(
+                StatusSubject::Device,
+                format!(
+                    "auto failed: no touchpad candidates among {} readable event device(s)",
+                    discovery.summaries.len()
+                ),
+            ),
+            [candidate] => StatusLine::ok(StatusSubject::Device, format_device_line(candidate)),
+            candidates => {
+                let devices = candidates
+                    .iter()
+                    .map(|candidate| candidate.path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                StatusLine::fail(
+                    StatusSubject::Device,
+                    format!("auto failed: multiple touchpad candidates: {devices}"),
+                )
+            }
+        },
+        Err(err) => StatusLine::fail(
+            StatusSubject::Device,
+            format!(
+                "auto failed: failed to list {}: {err}",
+                input_root.display()
+            ),
+        ),
+    }
+}
+
+fn zones_status_line(config: &EdgepadConfig) -> StatusLine {
+    let active_zones: Vec<Zone> = ordered_zones()
+        .iter()
+        .copied()
+        .filter(|zone| config.gestures.iter().any(|binding| binding.zone == *zone))
+        .collect();
+    let inactive_zones: Vec<Zone> = ordered_zones()
+        .iter()
+        .copied()
+        .filter(|zone| !active_zones.contains(zone))
+        .collect();
+
+    if active_zones.is_empty() {
+        return StatusLine::fail(StatusSubject::Zones, "none configured");
+    }
+
+    StatusLine::ok(
+        StatusSubject::Zones,
+        format!(
+            "{} active; {} passthrough; widths: {}",
+            zone_list_label(&active_zones),
+            zone_list_label(&inactive_zones),
+            edge_widths_label(config.active_edge_widths())
+        ),
+    )
+}
+
+fn actions_status_line(config: &EdgepadConfig) -> StatusLine {
+    if config.gestures.is_empty() {
+        return StatusLine::fail(StatusSubject::Actions, "no gesture bindings configured");
+    }
+
+    let command_count = config
+        .gestures
+        .iter()
+        .filter_map(|binding| match &binding.action {
+            crate::config::GestureActionConfig::Command { argv } => argv.first(),
+            crate::config::GestureActionConfig::Log => None,
+        })
+        .collect::<BTreeSet<_>>()
+        .len();
+
+    let detail = match command_count {
+        0 => format!(
+            "{}; log actions only",
+            binding_count_label(config.gestures.len())
+        ),
+        1 => format!("{}, 1 command", binding_count_label(config.gestures.len())),
+        count => format!(
+            "{}, {count} commands",
+            binding_count_label(config.gestures.len())
+        ),
+    };
+
+    StatusLine::ok(StatusSubject::Actions, detail)
+}
+
+fn service_status_line(service_name: &str) -> StatusLine {
+    match systemctl_user_show(service_name) {
+        Ok(output) if output.status_success => {
+            let load_state = property_value(&output.stdout, "LoadState").unwrap_or("unknown");
+            let active_state = property_value(&output.stdout, "ActiveState").unwrap_or("unknown");
+            let sub_state = property_value(&output.stdout, "SubState").unwrap_or("unknown");
+
+            if load_state == "not-found" {
+                StatusLine::fail(
+                    StatusSubject::Service,
+                    format!("{service_name} is not installed"),
+                )
+            } else if active_state == "active" {
+                StatusLine::ok(StatusSubject::Service, format!("active ({sub_state})"))
+            } else if active_state == "failed" {
+                StatusLine::fail(StatusSubject::Service, format!("failed ({sub_state})"))
+            } else {
+                StatusLine::fail(
+                    StatusSubject::Service,
+                    format!("{active_state} ({sub_state})"),
+                )
+            }
+        }
+        Ok(output) => StatusLine::warn(
+            StatusSubject::Service,
+            format!(
+                "unknown: systemctl --user failed: {}",
+                output.stderr_or_stdout()
+            ),
+        ),
+        Err(err) => StatusLine::warn(StatusSubject::Service, format!("unknown: {err}")),
+    }
+}
+
+fn systemctl_user_show(service_name: &str) -> Result<CommandOutput, String> {
+    command_output(
+        "systemctl",
+        &[
+            "--user",
+            "show",
+            service_name,
+            "-p",
+            "LoadState",
+            "-p",
+            "ActiveState",
+            "-p",
+            "SubState",
+        ],
+    )
+}
+
+fn command_output(program: &str, args: &[&str]) -> Result<CommandOutput, String> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .map_err(|err| format!("failed to run {program}: {err}"))?;
+
+    Ok(CommandOutput {
+        status_success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommandOutput {
+    status_success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+impl CommandOutput {
+    fn stderr_or_stdout(&self) -> String {
+        let stderr = self.stderr.trim();
+        if !stderr.is_empty() {
+            stderr.to_string()
+        } else {
+            self.stdout.trim().to_string()
+        }
+    }
+}
+
+fn status_result(lines: &[StatusLine]) -> StatusResult {
+    if lines
+        .iter()
+        .any(|line| line.subject != StatusSubject::Service && line.severity == StatusSeverity::Fail)
+    {
+        StatusResult::Misconfigured
+    } else if lines
+        .iter()
+        .any(|line| line.subject == StatusSubject::Service && line.severity == StatusSeverity::Fail)
+    {
+        StatusResult::NotRunning
+    } else if lines
+        .iter()
+        .any(|line| line.severity == StatusSeverity::Warn)
+    {
+        StatusResult::NeedsAttention
+    } else {
+        StatusResult::Running
+    }
+}
+
+fn ordered_zones() -> [Zone; 4] {
+    [Zone::Left, Zone::Right, Zone::Top, Zone::Bottom]
+}
+
+fn zone_list_label(zones: &[Zone]) -> String {
+    if zones.is_empty() {
+        return "none".to_string();
+    }
+
+    zones
+        .iter()
+        .map(|zone| zone_name(*zone))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn zone_name(zone: Zone) -> &'static str {
+    match zone {
+        Zone::Left => "left",
+        Zone::Right => "right",
+        Zone::Top => "top",
+        Zone::Bottom => "bottom",
+    }
+}
+
+fn edge_widths_label(widths: EdgeWidths) -> String {
+    format!(
+        "left {}, right {}, top {}, bottom {}",
+        edge_width_label(widths.left),
+        edge_width_label(widths.right),
+        edge_width_label(widths.top),
+        edge_width_label(widths.bottom)
+    )
+}
+
+fn edge_width_label(width: f32) -> String {
+    if width <= f32::EPSILON {
+        "off".to_string()
+    } else {
+        format!("{:.1}%", width * 100.0)
+    }
+}
+
+fn binding_count_label(count: usize) -> String {
+    match count {
+        1 => "1 binding".to_string(),
+        _ => format!("{count} bindings"),
+    }
+}
+
+fn property_value<'a>(output: &'a str, key: &str) -> Option<&'a str> {
+    output
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{key}=")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{GestureActionConfig, GestureBindingConfig};
+    use crate::core::GestureDirection;
+
+    #[test]
+    fn zones_status_reports_active_and_passthrough_edges() {
+        let config = EdgepadConfig {
+            device: DeviceConfig::Auto,
+            edge_width: 0.20,
+            gestures: vec![
+                GestureBindingConfig {
+                    zone: Zone::Right,
+                    direction: GestureDirection::Up,
+                    action: GestureActionConfig::Log,
+                },
+                GestureBindingConfig {
+                    zone: Zone::Top,
+                    direction: GestureDirection::Left,
+                    action: GestureActionConfig::Log,
+                },
+            ],
+        };
+
+        let line = zones_status_line(&config);
+
+        assert_eq!(line.severity, StatusSeverity::Ok);
+        assert_eq!(line.subject, StatusSubject::Zones);
+        assert_eq!(
+            line.detail,
+            "right, top active; left, bottom passthrough; widths: left off, right 20.0%, top 20.0%, bottom off"
+        );
+    }
+
+    #[test]
+    fn actions_status_counts_unique_command_programs() {
+        let config = EdgepadConfig {
+            device: DeviceConfig::Auto,
+            edge_width: 0.10,
+            gestures: vec![
+                GestureBindingConfig {
+                    zone: Zone::Left,
+                    direction: GestureDirection::Up,
+                    action: GestureActionConfig::Command {
+                        argv: vec!["pamixer".to_string(), "-i".to_string(), "5".to_string()],
+                    },
+                },
+                GestureBindingConfig {
+                    zone: Zone::Left,
+                    direction: GestureDirection::Down,
+                    action: GestureActionConfig::Command {
+                        argv: vec!["pamixer".to_string(), "-d".to_string(), "5".to_string()],
+                    },
+                },
+                GestureBindingConfig {
+                    zone: Zone::Right,
+                    direction: GestureDirection::Tap,
+                    action: GestureActionConfig::Log,
+                },
+            ],
+        };
+
+        let line = actions_status_line(&config);
+
+        assert_eq!(line.detail, "3 bindings, 1 command");
+    }
+
+    #[test]
+    fn status_result_prioritizes_misconfiguration_over_service_state() {
+        let lines = vec![
+            StatusLine::fail(StatusSubject::Service, "inactive"),
+            StatusLine::fail(StatusSubject::Device, "auto failed"),
+        ];
+
+        assert_eq!(status_result(&lines), StatusResult::Misconfigured);
+    }
+
+    #[test]
+    fn service_status_parses_active_systemd_unit() {
+        let output = CommandOutput {
+            status_success: true,
+            stdout: "LoadState=loaded\nActiveState=active\nSubState=running\n".to_string(),
+            stderr: String::new(),
+        };
+
+        assert_eq!(
+            property_value(&output.stdout, "ActiveState"),
+            Some("active")
+        );
+        assert_eq!(property_value(&output.stdout, "SubState"), Some("running"));
+    }
+}

--- a/tests/core_invariants.rs
+++ b/tests/core_invariants.rs
@@ -88,6 +88,46 @@ fn claimed_edge_touch_does_not_emit_initial_down_to_passthrough() {
 }
 
 #[test]
+fn inactive_edge_width_passes_edge_touch_through() {
+    let mut engine = Engine::new(
+        test_caps(),
+        EdgeWidths {
+            left: 0.0,
+            right: 0.10,
+            top: 0.0,
+            bottom: 0.0,
+        },
+    );
+
+    let down = engine
+        .process_frame(&[
+            Event::slot(0),
+            Event::tracking_id(21),
+            Event::x(20),
+            Event::y(300),
+        ])
+        .expect("left edge contact is valid");
+
+    assert_eq!(
+        down.passthrough,
+        vec![
+            Event::slot(0),
+            Event::tracking_id(21),
+            Event::x(20),
+            Event::y(300)
+        ]
+    );
+    assert!(down.gestures.is_empty());
+
+    let up = engine
+        .process_frame(&[Event::slot(0), Event::tracking_id(-1)])
+        .expect("inactive edge release passes through");
+
+    assert_eq!(up.passthrough, vec![Event::slot(0), Event::tracking_id(-1)]);
+    assert!(up.gestures.is_empty());
+}
+
+#[test]
 fn center_touch_is_passthrough_from_initial_down_to_release() {
     let mut engine = Engine::new(test_caps(), EdgeWidths::all(0.10));
 

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -33,37 +33,37 @@ fn doctor_cli_checks_config_and_action_executables() {
 
     assert!(!output.status.success(), "doctor should report failures");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("config path"), "stdout was: {stdout}");
+    assert!(stdout.contains("Config"), "stdout was: {stdout}");
+    assert!(stdout.contains("path"), "stdout was: {stdout}");
     assert!(
         stdout.contains(&config_path.display().to_string()),
         "stdout was: {stdout}"
     );
-    assert!(stdout.contains("config parse"), "stdout was: {stdout}");
+    assert!(stdout.contains("file"), "stdout was: {stdout}");
     assert!(
-        stdout.contains("gesture_bindings=1"),
+        stdout.contains("device auto, edge width 10.0%, 1 gesture binding"),
         "stdout was: {stdout}"
     );
-    assert!(stdout.contains("active zones"), "stdout was: {stdout}");
+    assert!(stdout.contains("zones"), "stdout was: {stdout}");
     assert!(
-        stdout.contains("active_zones=right"),
-        "stdout was: {stdout}"
-    );
-    assert!(
-        stdout.contains("inactive_zones=left,top,bottom"),
+        stdout.contains("claiming right; passthrough left, top, bottom"),
         "stdout was: {stdout}"
     );
     assert!(
-        stdout.contains("edge_widths=left=0.000 right=0.100 top=0.000 bottom=0.000"),
+        stdout.contains("widths: left off, right 10.0%, top off, bottom off"),
         "stdout was: {stdout}"
     );
-    assert!(stdout.contains("action executable"), "stdout was: {stdout}");
+    assert!(stdout.contains("Actions"), "stdout was: {stdout}");
+    assert!(stdout.contains("command"), "stdout was: {stdout}");
     assert!(
         stdout.contains(&missing_action.display().to_string()),
         "stdout was: {stdout}"
     );
-    assert!(stdout.contains("not found"), "stdout was: {stdout}");
+    assert!(stdout.contains("problem:"), "stdout was: {stdout}");
+    assert!(stdout.contains("right.up"), "stdout was: {stdout}");
+    assert!(stdout.contains("Summary"), "stdout was: {stdout}");
     assert!(
-        stdout.contains("gestures[0] right.up"),
+        stdout.contains("result: problems found"),
         "stdout was: {stdout}"
     );
 
@@ -98,7 +98,8 @@ fn doctor_cli_uses_config_device_without_cli_override() {
 
     assert!(!output.status.success(), "doctor should report failures");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("config device"), "stdout was: {stdout}");
+    assert!(stdout.contains("Config"), "stdout was: {stdout}");
+    assert!(stdout.contains("device"), "stdout was: {stdout}");
     assert!(
         stdout.contains(&missing_device.display().to_string()),
         "stdout was: {stdout}"

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -43,6 +43,19 @@ fn doctor_cli_checks_config_and_action_executables() {
         stdout.contains("gesture_bindings=1"),
         "stdout was: {stdout}"
     );
+    assert!(stdout.contains("active zones"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains("active_zones=right"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("inactive_zones=left,top,bottom"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("edge_widths=left=0.000 right=0.100 top=0.000 bottom=0.000"),
+        "stdout was: {stdout}"
+    );
     assert!(stdout.contains("action executable"), "stdout was: {stdout}");
     assert!(
         stdout.contains(&missing_action.display().to_string()),

--- a/tests/help_cli.rs
+++ b/tests/help_cli.rs
@@ -62,6 +62,10 @@ fn subcommand_help_flags_print_command_help() {
     for (command, usage) in [
         ("devices", "edgepad devices [--root <input-root>] [--all]"),
         (
+            "status",
+            "edgepad status [--config <file>] [--device auto|<event-node>] [--input-root <input-root>]",
+        ),
+        (
             "doctor",
             "edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>]",
         ),

--- a/tests/status_cli.rs
+++ b/tests/status_cli.rs
@@ -1,0 +1,133 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn edgepad() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_edgepad"))
+}
+
+#[test]
+fn status_cli_summarizes_config_zones_actions_and_device_state() {
+    let root = unique_temp_dir("edgepad-status-cli-input-root");
+    let config_path = unique_temp_path("edgepad-status-cli-config");
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_file(&config_path);
+    fs::create_dir_all(&root).expect("input root should be created");
+    write_status_config(&config_path, "auto");
+
+    let output = edgepad()
+        .arg("status")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--input-root")
+        .arg(&root)
+        .output()
+        .expect("edgepad binary should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("edgepad status"), "stdout was: {stdout}");
+    assert!(stdout.contains("Service"), "stdout was: {stdout}");
+    assert!(stdout.contains("Config"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains(&config_path.display().to_string()),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("Device   auto failed: no event devices"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("Zones    right active; left, top, bottom passthrough"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("widths: left off, right 10.0%, top off, bottom off"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("Actions  1 binding, 1 command"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("Result   misconfigured"),
+        "stdout was: {stdout}"
+    );
+
+    fs::remove_dir_all(root).expect("input root should be removed");
+    fs::remove_file(config_path).expect("config should be removed");
+}
+
+#[test]
+fn status_cli_loads_default_config_path_from_xdg_config_home() {
+    let root = unique_temp_dir("edgepad-status-cli-default-root");
+    let config_home = unique_temp_dir("edgepad-status-cli-config-home");
+    let config_path = config_home.join("edgepad/edgepad.toml");
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&config_home);
+    fs::create_dir_all(&root).expect("input root should be created");
+    write_status_config(&config_path, "auto");
+
+    let output = edgepad()
+        .env("XDG_CONFIG_HOME", &config_home)
+        .arg("status")
+        .arg("--input-root")
+        .arg(&root)
+        .output()
+        .expect("edgepad binary should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&config_path.display().to_string()),
+        "stdout was: {stdout}"
+    );
+
+    fs::remove_dir_all(root).expect("input root should be removed");
+    fs::remove_dir_all(config_home).expect("config home should be removed");
+}
+
+#[test]
+fn status_cli_rejects_unknown_option() {
+    let output = edgepad()
+        .arg("status")
+        .arg("--wat")
+        .output()
+        .expect("edgepad binary should run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown status option --wat"),
+        "stderr was: {stderr}"
+    );
+}
+
+fn write_status_config(path: &Path, device: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("config parent should be created");
+    }
+    fs::write(
+        path,
+        format!(
+            r#"
+device = "{device}"
+edge_width = 0.10
+
+[[gestures]]
+zone = "right"
+direction = "up"
+action = ["notify-send", "edgepad", "right-up"]
+"#,
+        ),
+    )
+    .expect("config should be written");
+}
+
+fn unique_temp_path(prefix: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("{}-{}", prefix, std::process::id()))
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("{}-{}", prefix, std::process::id()))
+}


### PR DESCRIPTION
## Summary

  Prepare edgepad v0.1.2.

  ## Changes

  - Add `edgepad status` for a short daemon/config/device/zones/actions summary.
  - Improve `edgepad doctor` output structure and readability.
  - Report active and passthrough gesture zones in diagnostics.
  - Claim only zones that have configured gesture bindings, leaving inactive edges as passthrough.
  - Bump package version to `0.1.2`.