### PR TITLE
Release v0.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
         run: ./install.sh --uninstall --purge --dry-run
 
       - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --locked
 
   nix:
     name: Nix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl linker
+        run: sudo apt-get update && sudo apt-get install --yes musl-tools
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -34,18 +39,23 @@ jobs:
         run: cargo test --locked
 
       - name: Build release binary
-        run: cargo build --release --locked
+        run: cargo build --release --locked --target x86_64-unknown-linux-musl
 
       - name: Prepare release assets
         run: |
           set -euo pipefail
           mkdir -p dist
-          cp target/release/edgepad dist/edgepad-x86_64-unknown-linux-gnu
-          strip dist/edgepad-x86_64-unknown-linux-gnu
+          cp target/x86_64-unknown-linux-musl/release/edgepad dist/edgepad-x86_64-unknown-linux-musl
+          strip dist/edgepad-x86_64-unknown-linux-musl
+          if readelf -l dist/edgepad-x86_64-unknown-linux-musl | grep -q 'INTERP'; then
+            echo "release binary unexpectedly requires a dynamic loader" >&2
+            exit 1
+          fi
+          dist/edgepad-x86_64-unknown-linux-musl --version
           cp packaging/70-edgepad.rules dist/70-edgepad.rules
           cp packaging/edgepad.service dist/edgepad.service
           cp examples/edgepad.toml.example dist/edgepad.toml.example
-          (cd dist && sha256sum edgepad-x86_64-unknown-linux-gnu 70-edgepad.rules edgepad.service edgepad.toml.example > checksums)
+          (cd dist && sha256sum edgepad-x86_64-unknown-linux-musl 70-edgepad.rules edgepad.service edgepad.toml.example > checksums)
 
       - name: Publish GitHub Release
         env:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Check the current daemon, config, device, zones, and actions:
 edgepad status
 ```
 
+The service becomes active only after the virtual touchpad is created and the physical device is
+grabbed. Status output includes the ready daemon's PID, version, and selected device when systemd
+provides them.
+
 Run deeper diagnostics for device access, action executables, and service state:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Example config:
 device = "auto"
 edge_width = 0.10
 tap_min_duration_ms = 80
+swipe_min_distance = 0.02
 
 [[sliders]]
 zone = "left"
@@ -168,6 +169,14 @@ edge_width = 0.10
 
 ```toml
 tap_min_duration_ms = 80
+```
+
+`swipe_min_distance` is the minimum normalized touchpad travel that turns an edge contact into a
+directional gesture. It defaults to `0.02`, or 2% of the corresponding touchpad axis. Smaller
+movement remains a tap, so the same physical gesture behaves consistently across coordinate ranges.
+
+```toml
+swipe_min_distance = 0.02
 ```
 
 Each gesture binding has a zone, direction, and action:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ curl -fsSL https://raw.githubusercontent.com/assembledev/edgepad/main/install.sh
 ```
 
 The installer downloads a statically linked x86_64 Linux release binary, installs udev rules, writes a default config to `~/.config/edgepad/edgepad.toml`, installs a systemd user service, starts it, and runs `edgepad doctor`.
+Running the installer again upgrades the installed files and restarts the active daemon before
+checking its health.
 
 Uninstall files created by the release installer:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Preview the install plan first:
 curl -fsSL https://raw.githubusercontent.com/assembledev/edgepad/main/install.sh | sh -s -- --dry-run
 ```
 
-The installer downloads the x86_64 Linux release binary, installs udev rules, writes a default config to `~/.config/edgepad/edgepad.toml`, installs a systemd user service, starts it, and runs `edgepad doctor`.
+The installer downloads a statically linked x86_64 Linux release binary, installs udev rules, writes a default config to `~/.config/edgepad/edgepad.toml`, installs a systemd user service, starts it, and runs `edgepad doctor`.
 
 Uninstall files created by the release installer:
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -79,6 +79,7 @@ The Home Manager module writes `~/.config/edgepad/edgepad.toml` and starts a sys
     device = "auto";
     edgeWidth = 0.10;
     tapMinDurationMs = 80;
+    swipeMinDistance = 0.02;
 
     gestures = [
       {

--- a/docs/passthrough-uinput.md
+++ b/docs/passthrough-uinput.md
@@ -66,6 +66,7 @@ For normal desktop use, run the daemon as a user service with access to `/dev/in
 device = "auto"
 edge_width = 0.10
 tap_min_duration_ms = 80
+swipe_min_distance = 0.02
 
 [[gestures]]
 zone = "top"

--- a/docs/passthrough-uinput.md
+++ b/docs/passthrough-uinput.md
@@ -57,6 +57,9 @@ edgepad daemon --config ~/.config/edgepad/edgepad.toml
 ```
 
 It uses the same proxy runtime as the bounded mode and stops on Ctrl+C or SIGTERM. During shutdown it drains briefly until the physical touchpad is idle, emits cleanup output, and ungrabs the physical device.
+The packaged systemd units use `Type=notify`: they become active only after `/dev/uinput` setup and
+the physical-device grab both succeed. While startup retry is waiting for hardware or permissions,
+systemd keeps the service in `activating` instead of reporting a false ready state.
 
 For normal desktop use, run the daemon as a user service with access to `/dev/input` and `/dev/uinput`. That lets gesture actions inherit the user session. Running the daemon with `sudo` is useful for manual diagnostics, but command actions then run with root's environment.
 

--- a/docs/passthrough-uinput.md
+++ b/docs/passthrough-uinput.md
@@ -105,7 +105,10 @@ Those values can follow an edge-owned contact while another center contact is ac
 - `BTN_TOUCH` follows the count of unclaimed active contacts;
 - `BTN_TOOL_FINGER`, `BTN_TOOL_DOUBLETAP`, and related tool keys follow the unclaimed active contact count;
 - legacy `ABS_X/Y` come from a representative unclaimed active slot;
-- `SYN_DROPPED` releases tracked virtual contacts and marks resync.
+- `SYN_DROPPED` releases tracked virtual contacts, ignores the unreliable tail through the next
+  `SYN_REPORT`, then queries the kernel's current multitouch slot state. Contacts that were already
+  held during resync are restored as passthrough until release so incomplete history cannot create
+  a gesture.
 
 ## uinput batching
 

--- a/docs/replay-format.md
+++ b/docs/replay-format.md
@@ -27,6 +27,10 @@ ABS_MT_SLOT 0 # inline comment
 `SYN_REPORT` ends the current frame. Events before the next `SYN_REPORT` are processed together.
 
 `SYN_DROPPED` creates a standalone frame that tells the engine to clear local touch state and require resync.
+The live proxy additionally ignores events through the next `SYN_REPORT`, queries the kernel slot
+snapshot, and restores already-held contacts as passthrough. Text replay has no physical device to
+query, so a fixture must provide a fresh complete contact after `SYN_DROPPED` when it wants to model
+post-resync input.
 
 ## Raw dump syntax
 

--- a/examples/edgepad.toml.example
+++ b/examples/edgepad.toml.example
@@ -1,6 +1,7 @@
 device = "auto"
 edge_width = 0.10
 tap_min_duration_ms = 80
+swipe_min_distance = 0.02
 
 [[sliders]]
 zone = "left"

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ CONFIG_DIR="${CONFIG_HOME}/edgepad"
 CONFIG_FILE="${CONFIG_DIR}/edgepad.toml"
 SYSTEMD_USER_DIR="${CONFIG_HOME}/systemd/user"
 SERVICE_FILE="${SYSTEMD_USER_DIR}/edgepad.service"
-UDEV_RULE_FILE="/etc/udev/rules.d/70-edgepad.rules"
+UDEV_RULE_FILE="${EDGEPAD_UDEV_RULE_FILE:-/etc/udev/rules.d/70-edgepad.rules}"
 DRY_RUN=0
 MODE="install"
 PURGE=0
@@ -134,7 +134,9 @@ print_install_dry_run_plan() {
     info "  ${tmp_dir}/edgepad.service -> ${SERVICE_FILE}"
     info "Would run:"
     info "  systemctl --user daemon-reload"
-    info "  systemctl --user enable --now edgepad.service"
+    info "  systemctl --user enable edgepad.service"
+    info "  systemctl --user restart edgepad.service"
+    info "  systemctl --user is-active --quiet edgepad.service"
     info ""
     info "Would run:"
     info "  ${BIN_DIR}/edgepad doctor"
@@ -307,7 +309,9 @@ fi
 
 run install -Dm0644 "${tmp_dir}/edgepad.service" "$SERVICE_FILE"
 run systemctl --user daemon-reload
-run systemctl --user enable --now edgepad.service
+run systemctl --user enable edgepad.service
+run systemctl --user restart edgepad.service
+run systemctl --user is-active --quiet edgepad.service
 run "${BIN_DIR}/edgepad" doctor
 
 info "edgepad installed"

--- a/install.sh
+++ b/install.sh
@@ -245,7 +245,7 @@ kernel="$(uname -s)"
 machine="$(uname -m)"
 case "${kernel}-${machine}" in
     Linux-x86_64|Linux-amd64)
-        target="x86_64-unknown-linux-gnu"
+        target="x86_64-unknown-linux-musl"
         ;;
     *)
         die "unsupported platform: ${kernel}-${machine}; the release installer ships x86_64 Linux only"

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -204,6 +204,9 @@ in
       };
 
       Service = {
+        Type = "notify";
+        NotifyAccess = "main";
+        TimeoutStartSec = "45s";
         ExecStart = "${lib.getExe cfg.package} daemon --config ${configFile}";
         Restart = "on-failure";
         RestartSec = "1s";

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -105,6 +105,7 @@ let
     device = cfg.device;
     edge_width = cfg.edgeWidth;
     tap_min_duration_ms = cfg.tapMinDurationMs;
+    swipe_min_distance = cfg.swipeMinDistance;
     gestures = map (gesture: {
       inherit (gesture) zone direction action;
     }) cfg.gestures;
@@ -145,6 +146,18 @@ in
       type = lib.types.ints.between 0 10000;
       default = 80;
       description = "Minimum edge contact duration in milliseconds required for a tap gesture.";
+    };
+
+    swipeMinDistance = lib.mkOption {
+      type = lib.types.float;
+      default = 0.02;
+      apply =
+        value:
+        if value > 0.0 && value <= 1.0 then
+          value
+        else
+          throw "services.edgepad.swipeMinDistance must be > 0 and <= 1";
+      description = "Normalized touchpad travel required to classify an edge contact as a swipe.";
     };
 
     gestures = lib.mkOption {

--- a/nix/module-tests.nix
+++ b/nix/module-tests.nix
@@ -147,6 +147,9 @@ let
     assert lib.hasInfix "daemon --config" (
       builtins.unsafeDiscardStringContext homeService.Service.ExecStart
     );
+    assert homeService.Service.Type == "notify";
+    assert homeService.Service.NotifyAccess == "main";
+    assert homeService.Service.TimeoutStartSec == "45s";
     pkgs.runCommand "edgepad-module-tests" { } ''
       set -eu
       grep -F 'device = "auto"' ${homeConfigFile}

--- a/nix/module-tests.nix
+++ b/nix/module-tests.nix
@@ -91,6 +91,7 @@ let
           device = "auto";
           edgeWidth = 0.1;
           tapMinDurationMs = 90;
+          swipeMinDistance = 0.03;
           gestures = [
             {
               zone = "right";
@@ -151,6 +152,7 @@ let
       grep -F 'device = "auto"' ${homeConfigFile}
       grep -F 'edge_width = 0.1' ${homeConfigFile}
       grep -F 'tap_min_duration_ms = 90' ${homeConfigFile}
+      grep -F 'swipe_min_distance = 0.03' ${homeConfigFile}
       grep -F '[[gestures]]' ${homeConfigFile}
       grep -F 'zone = "right"' ${homeConfigFile}
       grep -F 'direction = "down"' ${homeConfigFile}

--- a/packaging/edgepad.service
+++ b/packaging/edgepad.service
@@ -3,7 +3,9 @@ Description=edgepad touchpad edge gesture daemon
 Documentation=https://github.com/assembledev/edgepad
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
+TimeoutStartSec=45s
 ExecStart=%h/.local/bin/edgepad daemon --config %h/.config/edgepad/edgepad.toml
 Restart=on-failure
 RestartSec=1s

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,13 +17,14 @@ use crate::device::{
 
 pub const DEFAULT_EDGE_WIDTH: f32 = 0.10;
 pub const DEFAULT_SLIDER_STEP: f32 = 0.04;
-pub use crate::core::DEFAULT_TAP_MIN_DURATION_MS;
+pub use crate::core::{DEFAULT_SWIPE_MIN_DISTANCE, DEFAULT_TAP_MIN_DURATION_MS};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct EdgepadConfig {
     pub device: DeviceConfig,
     pub edge_width: f32,
     pub tap_min_duration_ms: u64,
+    pub swipe_min_distance: f32,
     pub gestures: Vec<GestureBindingConfig>,
     pub sliders: Vec<SliderBindingConfig>,
 }
@@ -34,6 +35,7 @@ impl Default for EdgepadConfig {
             device: DeviceConfig::Auto,
             edge_width: DEFAULT_EDGE_WIDTH,
             tap_min_duration_ms: DEFAULT_TAP_MIN_DURATION_MS,
+            swipe_min_distance: DEFAULT_SWIPE_MIN_DISTANCE,
             gestures: Vec::new(),
             sliders: Vec::new(),
         }
@@ -58,6 +60,10 @@ impl EdgepadConfig {
         if let Some(tap_min_duration_ms) = raw.tap_min_duration_ms {
             config.tap_min_duration_ms =
                 validate_tap_min_duration_ms(tap_min_duration_ms, "tap_min_duration_ms")?;
+        }
+        if let Some(swipe_min_distance) = raw.swipe_min_distance {
+            config.swipe_min_distance =
+                validate_swipe_min_distance(swipe_min_distance, "swipe_min_distance")?;
         }
 
         for (index, raw_binding) in raw.gestures.into_iter().enumerate() {
@@ -122,6 +128,7 @@ impl EdgepadConfig {
     pub fn engine_options(&self) -> EngineOptions {
         EngineOptions {
             tap_min_duration: Duration::from_millis(self.tap_min_duration_ms),
+            swipe_min_distance: self.swipe_min_distance,
         }
     }
 
@@ -381,6 +388,13 @@ fn validate_tap_min_duration_ms(parsed: u64, name: &str) -> Result<u64, String> 
     Ok(parsed)
 }
 
+fn validate_swipe_min_distance(parsed: f32, name: &str) -> Result<f32, String> {
+    if !(parsed > 0.0 && parsed <= 1.0) {
+        return Err(format!("{name} must be > 0 and <= 1"));
+    }
+    Ok(parsed)
+}
+
 fn resolve_auto_touchpad(input_root: &Path) -> Result<PathBuf, String> {
     let report = discover_device_report(input_root)
         .map_err(|err| format!("failed to list {}: {err}", input_root.display()))?;
@@ -519,6 +533,7 @@ struct RawEdgepadConfig {
     device: Option<String>,
     edge_width: Option<f32>,
     tap_min_duration_ms: Option<u64>,
+    swipe_min_distance: Option<f32>,
     #[serde(default)]
     gestures: Vec<RawGestureBindingConfig>,
     #[serde(default)]
@@ -624,6 +639,7 @@ mod tests {
             device = "/dev/input/event7"
             edge_width = 0.20
             tap_min_duration_ms = 90
+            swipe_min_distance = 0.03
 
             [[gestures]]
             zone = "left"
@@ -644,10 +660,12 @@ mod tests {
         );
         assert_eq!(config.edge_width, 0.20);
         assert_eq!(config.tap_min_duration_ms, 90);
+        assert_eq!(config.swipe_min_distance, 0.03);
         assert_eq!(
             config.engine_options().tap_min_duration,
             Duration::from_millis(90)
         );
+        assert_eq!(config.engine_options().swipe_min_distance, 0.03);
         assert_eq!(
             config.gestures,
             vec![
@@ -684,6 +702,7 @@ mod tests {
         .expect("config should parse");
 
         assert_eq!(config.tap_min_duration_ms, DEFAULT_TAP_MIN_DURATION_MS);
+        assert_eq!(config.swipe_min_distance, DEFAULT_SWIPE_MIN_DISTANCE);
     }
 
     #[test]
@@ -796,6 +815,25 @@ mod tests {
         assert_eq!(
             result.as_ref().err().map(String::as_str),
             Some("tap_min_duration_ms must be <= 10000")
+        );
+    }
+
+    #[test]
+    fn edgepad_config_rejects_invalid_swipe_min_distance() {
+        let result = EdgepadConfig::parse(
+            r#"
+            swipe_min_distance = 0.0
+
+            [[gestures]]
+            zone = "left"
+            direction = "tap"
+            action = ["pamixer", "-t"]
+            "#,
+        );
+
+        assert_eq!(
+            result.as_ref().err().map(String::as_str),
+            Some("swipe_min_distance must be > 0 and <= 1")
         );
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -241,10 +241,11 @@ fn check_config(config: &DoctorConfig, report: &mut DoctorReport) -> Option<Edge
                 DoctorSection::Config,
                 "file",
                 format!(
-                    "device {}, edge width {}, tap min {}ms, {}, {}",
+                    "device {}, edge width {}, tap min {}ms, swipe min {}, {}, {}",
                     device_config_value_label(&edgepad_config.device),
                     percent_label(edgepad_config.edge_width),
                     edgepad_config.tap_min_duration_ms,
+                    percent_label(edgepad_config.swipe_min_distance),
                     gesture_binding_count_label(edgepad_config.gestures.len()),
                     slider_count_label(edgepad_config.sliders.len())
                 ),
@@ -1205,7 +1206,10 @@ fn slider_direction_name(direction: SliderDirection) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{GestureActionConfig, GestureBindingConfig, DEFAULT_TAP_MIN_DURATION_MS};
+    use crate::config::{
+        GestureActionConfig, GestureBindingConfig, DEFAULT_SWIPE_MIN_DISTANCE,
+        DEFAULT_TAP_MIN_DURATION_MS,
+    };
 
     #[test]
     fn parses_current_tags_from_udevadm_properties() {
@@ -1253,6 +1257,7 @@ mod tests {
             device: DeviceConfig::Auto,
             edge_width: 0.20,
             tap_min_duration_ms: DEFAULT_TAP_MIN_DURATION_MS,
+            swipe_min_distance: DEFAULT_SWIPE_MIN_DISTANCE,
             gestures: vec![
                 GestureBindingConfig {
                     zone: Zone::Right,
@@ -1281,6 +1286,7 @@ mod tests {
             device: DeviceConfig::Path(PathBuf::from("/dev/input/event7")),
             edge_width: 0.10,
             tap_min_duration_ms: DEFAULT_TAP_MIN_DURATION_MS,
+            swipe_min_distance: DEFAULT_SWIPE_MIN_DISTANCE,
             gestures: Vec::new(),
             sliders: Vec::new(),
         };
@@ -1302,6 +1308,7 @@ mod tests {
             device: DeviceConfig::Auto,
             edge_width: 0.10,
             tap_min_duration_ms: DEFAULT_TAP_MIN_DURATION_MS,
+            swipe_min_distance: DEFAULT_SWIPE_MIN_DISTANCE,
             gestures: Vec::new(),
             sliders: Vec::new(),
         };
@@ -1327,6 +1334,7 @@ mod tests {
             device: DeviceConfig::Auto,
             edge_width: 0.10,
             tap_min_duration_ms: DEFAULT_TAP_MIN_DURATION_MS,
+            swipe_min_distance: DEFAULT_SWIPE_MIN_DISTANCE,
             gestures: vec![GestureBindingConfig {
                 zone: Zone::Right,
                 direction: GestureDirection::Up,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,14 @@ pub mod core {
         pub tracking_id: i32,
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ResyncContact {
+        pub slot: i32,
+        pub tracking_id: i32,
+        pub x: i32,
+        pub y: i32,
+    }
+
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct FrameOutput {
         pub passthrough: Vec<Event>,
@@ -305,6 +313,36 @@ pub mod core {
             timestamp: Duration,
         ) -> Result<FrameOutput, SlotError> {
             self.process_frame_with_time(frame, Some(timestamp))
+        }
+
+        pub fn restore_passthrough_contacts(
+            &mut self,
+            contacts: &[ResyncContact],
+        ) -> Result<FrameOutput, SlotError> {
+            self.reset_for_resync();
+            let mut output = FrameOutput::empty();
+
+            for contact in contacts {
+                self.ensure_slot(contact.slot)?;
+                self.current_slot = contact.slot;
+                let slot = self.slot_mut(contact.slot)?;
+                slot.active = true;
+                slot.tracking_id = Some(contact.tracking_id);
+                slot.ownership = Ownership::Passthrough;
+                slot.start_x = Some(contact.x);
+                slot.start_y = Some(contact.y);
+                slot.current_x = Some(contact.x);
+                slot.current_y = Some(contact.y);
+
+                output.passthrough.extend([
+                    Event::slot(contact.slot),
+                    Event::tracking_id(contact.tracking_id),
+                    Event::x(contact.x),
+                    Event::y(contact.y),
+                ]);
+            }
+
+            Ok(output)
         }
 
         fn process_frame_with_time(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod device;
 pub mod doctor;
 pub mod dump;
+pub mod notify;
 pub mod proxy;
 pub mod raw;
 pub mod status;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod core {
     use std::time::Duration;
 
     pub const DEFAULT_TAP_MIN_DURATION_MS: u64 = 80;
+    pub const DEFAULT_SWIPE_MIN_DISTANCE: f32 = 0.02;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct AxisRange {
@@ -28,6 +29,11 @@ pub mod core {
         fn normalize(self, value: i32) -> f32 {
             let span = (self.max - self.min).max(1) as f32;
             (value - self.min) as f32 / span
+        }
+
+        fn normalize_delta(self, start: i32, end: i32) -> f32 {
+            let span = (self.max - self.min).max(1) as f32;
+            (end - start) as f32 / span
         }
     }
 
@@ -135,15 +141,17 @@ pub mod core {
         pub step: f32,
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq)]
     pub struct EngineOptions {
         pub tap_min_duration: Duration,
+        pub swipe_min_distance: f32,
     }
 
     impl Default for EngineOptions {
         fn default() -> Self {
             Self {
                 tap_min_duration: Duration::from_millis(DEFAULT_TAP_MIN_DURATION_MS),
+                swipe_min_distance: DEFAULT_SWIPE_MIN_DISTANCE,
             }
         }
     }
@@ -421,9 +429,10 @@ pub mod core {
                 Ownership::Claimed(zone) => {
                     let releases_slider_zone = self.slider_for_zone(zone).is_some();
                     let options = self.options;
+                    let capabilities = self.caps;
                     let slot_state = self.slot_mut(slot)?;
                     if let Some(gesture) =
-                        classify_gesture(slot, zone, slot_state, options, timestamp)
+                        classify_gesture(capabilities, slot, zone, slot_state, options, timestamp)
                     {
                         if !releases_slider_zone || gesture.direction == GestureDirection::Tap {
                             output.gestures.push(gesture);
@@ -659,6 +668,7 @@ pub mod core {
     }
 
     fn classify_gesture(
+        capabilities: Capabilities,
         slot: i32,
         zone: Zone,
         state: &SlotState,
@@ -669,25 +679,26 @@ pub mod core {
         let start_y = state.start_y?;
         let current_x = state.current_x.unwrap_or(start_x);
         let current_y = state.current_y.unwrap_or(start_y);
-        let dx = current_x - start_x;
-        let dy = current_y - start_y;
+        let dx = capabilities.x.normalize_delta(start_x, current_x);
+        let dy = capabilities.y.normalize_delta(start_y, current_y);
 
-        let direction = if dx.abs() < 20 && dy.abs() < 20 {
-            if !tap_duration_is_valid(state.started_at, released_at, options.tap_min_duration) {
-                return None;
-            }
-            GestureDirection::Tap
-        } else if dx.abs() >= dy.abs() {
-            if dx >= 0 {
-                GestureDirection::Right
+        let direction =
+            if dx.abs() < options.swipe_min_distance && dy.abs() < options.swipe_min_distance {
+                if !tap_duration_is_valid(state.started_at, released_at, options.tap_min_duration) {
+                    return None;
+                }
+                GestureDirection::Tap
+            } else if dx.abs() >= dy.abs() {
+                if dx >= 0.0 {
+                    GestureDirection::Right
+                } else {
+                    GestureDirection::Left
+                }
+            } else if dy >= 0.0 {
+                GestureDirection::Down
             } else {
-                GestureDirection::Left
-            }
-        } else if dy >= 0 {
-            GestureDirection::Down
-        } else {
-            GestureDirection::Up
-        };
+                GestureDirection::Up
+            };
 
         Some(Gesture {
             zone,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use edgepad::dump::{
     write_raw_events_with_limit, WriteEventsResult,
 };
 use edgepad::proxy::{
-    run_proxy, run_proxy_with_gesture_handler, ProxyMode, ProxyRunConfig, ProxyRunLimit,
+    run_proxy, run_proxy_with_gesture_handler_and_ready, ProxyMode, ProxyRunConfig, ProxyRunLimit,
     ProxyRunSummary, StopAfterFrameLimit, StopToken, DEFAULT_EDGE_WIDTH,
 };
 use edgepad::raw::{
@@ -864,7 +864,7 @@ fn run_daemon_proxy_with_startup_retry(
                 last_announced_device = Some(device_path.clone());
             }
 
-            run_proxy_with_gesture_handler(
+            run_proxy_with_gesture_handler_and_ready(
                 &ProxyRunConfig {
                     device_path,
                     limit: ProxyRunLimit::UntilStopped {
@@ -877,6 +877,15 @@ fn run_daemon_proxy_with_startup_retry(
                     mode: ProxyMode::UinputGrab,
                 },
                 action_dispatcher,
+                &mut |ready_device| {
+                    if edgepad::notify::notify_ready(ready_device)? {
+                        eprintln!(
+                            "edgepad daemon: systemd ready notification sent for {}",
+                            ready_device.display()
+                        );
+                    }
+                    Ok(())
+                },
             )
         });
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,0 +1,134 @@
+use std::env;
+use std::ffi::OsStr;
+use std::io;
+use std::mem;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+pub fn notify_ready(device_path: &Path) -> Result<bool, String> {
+    let payload = ready_payload(device_path);
+    let sent = notify(payload.as_bytes())?;
+    if sent {
+        env::remove_var("NOTIFY_SOCKET");
+    }
+    Ok(sent)
+}
+
+fn ready_payload(device_path: &Path) -> String {
+    format!(
+        "READY=1\nSTATUS=edgepad {} ready on {}\nMAINPID={}",
+        env!("CARGO_PKG_VERSION"),
+        device_path.display(),
+        std::process::id()
+    )
+}
+
+fn notify(payload: &[u8]) -> Result<bool, String> {
+    let Some(socket) = env::var_os("NOTIFY_SOCKET") else {
+        return Ok(false);
+    };
+    send_notification_to(&socket, payload)
+        .map_err(|err| format!("failed to notify systemd that edgepad is ready: {err}"))?;
+    Ok(true)
+}
+
+fn send_notification_to(socket: &OsStr, payload: &[u8]) -> io::Result<()> {
+    let raw_fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_DGRAM | libc::SOCK_CLOEXEC, 0) };
+    if raw_fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+    let mut address = unsafe { mem::zeroed::<libc::sockaddr_un>() };
+    address.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    let socket_bytes = socket.as_bytes();
+    let path_offset = mem::size_of::<libc::sa_family_t>();
+    let path_len = if let Some(abstract_name) = socket_bytes.strip_prefix(b"@") {
+        if abstract_name.len() + 1 > address.sun_path.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "abstract NOTIFY_SOCKET path is too long",
+            ));
+        }
+        for (destination, source) in address.sun_path[1..].iter_mut().zip(abstract_name) {
+            *destination = *source as libc::c_char;
+        }
+        abstract_name.len() + 1
+    } else {
+        if socket_bytes.len() + 1 > address.sun_path.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "NOTIFY_SOCKET path is too long",
+            ));
+        }
+        for (destination, source) in address.sun_path.iter_mut().zip(socket_bytes) {
+            *destination = *source as libc::c_char;
+        }
+        socket_bytes.len() + 1
+    };
+    let address_len = (path_offset + path_len) as libc::socklen_t;
+
+    let sent = unsafe {
+        libc::sendto(
+            fd.as_raw_fd(),
+            payload.as_ptr().cast(),
+            payload.len(),
+            libc::MSG_NOSIGNAL,
+            (&address as *const libc::sockaddr_un).cast(),
+            address_len,
+        )
+    };
+    if sent < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if sent as usize != payload.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "systemd readiness datagram was truncated",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixDatagram;
+    use std::time::Duration;
+
+    #[test]
+    fn ready_payload_identifies_version_device_and_main_process() {
+        let payload = ready_payload(Path::new("/dev/input/event7"));
+
+        assert!(payload.starts_with("READY=1\n"));
+        assert!(payload.contains(&format!("edgepad {} ready", env!("CARGO_PKG_VERSION"))));
+        assert!(payload.contains("/dev/input/event7"));
+        assert!(payload.contains(&format!("MAINPID={}", std::process::id())));
+    }
+
+    #[test]
+    #[ignore = "requires permission to create Unix datagram sockets"]
+    fn sends_readiness_payload_to_filesystem_notify_socket() {
+        let socket_path = std::env::temp_dir().join(format!(
+            "edgepad-notify-{}-{}.sock",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let _ = std::fs::remove_file(&socket_path);
+        let receiver = UnixDatagram::bind(&socket_path).expect("notify socket should bind");
+        receiver
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("read timeout should be configured");
+
+        send_notification_to(socket_path.as_os_str(), b"READY=1\nSTATUS=test")
+            .expect("notification should send");
+        let mut buffer = [0_u8; 128];
+        let received = receiver
+            .recv(&mut buffer)
+            .expect("notification should arrive");
+
+        assert_eq!(&buffer[..received], b"READY=1\nSTATUS=test");
+        std::fs::remove_file(socket_path).expect("notify socket should be removed");
+    }
+}

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -10,14 +10,14 @@ use std::time::{Duration, Instant, UNIX_EPOCH};
 #[cfg(test)]
 use crate::core::SliderAxis;
 use crate::core::{
-    Capabilities, EdgeWidths, Engine, EngineOptions, Gesture, GestureDirection, SliderDirection,
-    SliderSpec, SliderStep, Zone,
+    Capabilities, EdgeWidths, Engine, EngineOptions, Gesture, GestureDirection, ResyncContact,
+    SliderDirection, SliderSpec, SliderStep, Zone,
 };
 use crate::dump::capabilities_from_raw_device;
 use crate::raw::{
-    extract_core_events, route_raw_frame, RawEvent, RawFrame, RawOutputComposer, RawOutputSink,
-    RecordingRawOutputSink, ABS_MT_SLOT, ABS_MT_TRACKING_ID, BTN_TOUCH, EV_ABS, EV_KEY, EV_SYN,
-    SYN_DROPPED, SYN_REPORT,
+    extract_core_events, route_raw_frame, route_resync_contacts, RawEvent, RawFrame,
+    RawOutputComposer, RawOutputSink, RecordingRawOutputSink, ABS_MT_POSITION_X, ABS_MT_POSITION_Y,
+    ABS_MT_SLOT, ABS_MT_TRACKING_ID, BTN_TOUCH, EV_ABS, EV_KEY, EV_SYN, SYN_DROPPED, SYN_REPORT,
 };
 use crate::uinput::{
     build_virtual_touchpad, UinputEventWriter, UinputRawOutputSink, VirtualTouchpadSpec,
@@ -72,6 +72,43 @@ impl PendingRawFrame {
             std::mem::take(&mut self.events),
             timestamp,
         ))
+    }
+
+    fn discard(&mut self) {
+        self.events.clear();
+        self.timestamp = None;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResyncStreamAction {
+    ProcessNormally,
+    StartResync,
+    CompleteResync,
+    Ignore,
+}
+
+fn observe_resync_stream_event(
+    resync_pending: &mut bool,
+    pending: &mut PendingRawFrame,
+    event: RawEvent,
+) -> ResyncStreamAction {
+    if *resync_pending {
+        return match (event.kind, event.code) {
+            (EV_SYN, SYN_REPORT) => {
+                *resync_pending = false;
+                ResyncStreamAction::CompleteResync
+            }
+            _ => ResyncStreamAction::Ignore,
+        };
+    }
+
+    if (event.kind, event.code) == (EV_SYN, SYN_DROPPED) {
+        pending.discard();
+        *resync_pending = true;
+        ResyncStreamAction::StartResync
+    } else {
+        ResyncStreamAction::ProcessNormally
     }
 }
 
@@ -351,9 +388,17 @@ fn physical_touch_snapshot_is_down(btn_touch_down: bool, mt_tracking_ids: &[i32]
 }
 
 fn mt_tracking_ids(device: &RawDevice, capabilities: Capabilities) -> Result<Vec<i32>, String> {
+    mt_slot_values(device, capabilities, ABS_MT_TRACKING_ID)
+}
+
+fn mt_slot_values(
+    device: &RawDevice,
+    capabilities: Capabilities,
+    axis_code: u16,
+) -> Result<Vec<i32>, String> {
     let slot_count = (capabilities.slot_max - capabilities.slot_min + 1) as usize;
     let mut request = vec![0_i32; slot_count + 1];
-    request[0] = ABS_MT_TRACKING_ID as i32;
+    request[0] = axis_code as i32;
     let request_bytes = unsafe {
         std::slice::from_raw_parts_mut(
             request.as_mut_ptr().cast::<u8>(),
@@ -361,9 +406,46 @@ fn mt_tracking_ids(device: &RawDevice, capabilities: Capabilities) -> Result<Vec
         )
     };
     unsafe { eviocgmtslots(device.as_raw_fd(), request_bytes) }.map_err(|err| {
-        format!("failed to read current multitouch slot state before live proxy: {err}")
+        format!("failed to read current multitouch slot axis {axis_code:#x}: {err}")
     })?;
     Ok(request[1..].to_vec())
+}
+
+fn read_resync_contacts(
+    device: &RawDevice,
+    capabilities: Capabilities,
+) -> Result<Vec<ResyncContact>, String> {
+    let tracking_ids = mt_slot_values(device, capabilities, ABS_MT_TRACKING_ID)?;
+    let x_values = mt_slot_values(device, capabilities, ABS_MT_POSITION_X)?;
+    let y_values = mt_slot_values(device, capabilities, ABS_MT_POSITION_Y)?;
+    Ok(resync_contacts_from_slot_values(
+        capabilities,
+        &tracking_ids,
+        &x_values,
+        &y_values,
+    ))
+}
+
+fn resync_contacts_from_slot_values(
+    capabilities: Capabilities,
+    tracking_ids: &[i32],
+    x_values: &[i32],
+    y_values: &[i32],
+) -> Vec<ResyncContact> {
+    tracking_ids
+        .iter()
+        .zip(x_values)
+        .zip(y_values)
+        .enumerate()
+        .filter_map(|(index, ((tracking_id, x), y))| {
+            (*tracking_id >= 0).then_some(ResyncContact {
+                slot: capabilities.slot_min + index as i32,
+                tracking_id: *tracking_id,
+                x: *x,
+                y: *y,
+            })
+        })
+        .collect()
 }
 
 fn settle_after_uinput_proxy_run<W>(
@@ -436,6 +518,7 @@ where
     let mut stopper = ProxyLoopStopper::new(limit);
     let mut drain_deadline: Option<Instant> = None;
     let mut pending = PendingRawFrame::default();
+    let mut resync_pending = false;
 
     loop {
         let timeout = drain_deadline
@@ -462,6 +545,45 @@ where
         for raw in events {
             let event = raw;
             let raw = event.raw;
+            match observe_resync_stream_event(&mut resync_pending, &mut pending, raw) {
+                ResyncStreamAction::Ignore => continue,
+                ResyncStreamAction::StartResync => {
+                    let dropped = raw_frame_with_timestamp(vec![raw], event.timestamp);
+                    process_proxy_raw_frame(
+                        &dropped,
+                        &mut touch_state,
+                        &mut engine,
+                        &mut composer,
+                        sink,
+                        &mut stats,
+                        handler,
+                    )?;
+                    touch_state.mark_desynchronized();
+                    stats.input_frame_boundaries += 1;
+                    continue;
+                }
+                ResyncStreamAction::CompleteResync => {
+                    let contacts = read_resync_contacts(device, config.capabilities)?;
+                    process_proxy_resync_contacts(
+                        &contacts,
+                        &mut engine,
+                        &mut composer,
+                        sink,
+                        &mut stats,
+                        handler,
+                    )?;
+                    touch_state.restore_contacts(&contacts);
+                    stats.input_frame_boundaries += 1;
+                    if stopper.observe_frame_boundary(touch_state.is_touch_down()) {
+                        stats.idle_drain_frame_boundaries = stopper.extra_frame_boundaries();
+                        finish_proxy_output(&mut composer, sink, &mut stats)?;
+                        return Ok(stats);
+                    }
+                    stats.idle_drain_frame_boundaries = stopper.extra_frame_boundaries();
+                    continue;
+                }
+                ResyncStreamAction::ProcessNormally => {}
+            }
             match (raw.kind, raw.code) {
                 (EV_SYN, SYN_REPORT) => {
                     if let Some(frame) = pending.take_frame(event.timestamp) {
@@ -475,41 +597,6 @@ where
                             handler,
                         )?;
                     }
-                    stats.input_frame_boundaries += 1;
-                    if stopper.observe_frame_boundary(touch_state.is_touch_down()) {
-                        stats.idle_drain_frame_boundaries = stopper.extra_frame_boundaries();
-                        finish_proxy_output(&mut composer, sink, &mut stats)?;
-                        return Ok(stats);
-                    }
-                    if stopper.is_draining() && drain_deadline.is_none() {
-                        drain_deadline = stopper
-                            .drain_timeout()
-                            .map(|timeout| Instant::now() + timeout);
-                    }
-                    stats.idle_drain_frame_boundaries = stopper.extra_frame_boundaries();
-                }
-                (EV_SYN, SYN_DROPPED) => {
-                    if let Some(frame) = pending.take_frame(event.timestamp) {
-                        process_proxy_raw_frame(
-                            &frame,
-                            &mut touch_state,
-                            &mut engine,
-                            &mut composer,
-                            sink,
-                            &mut stats,
-                            handler,
-                        )?;
-                    }
-                    let dropped = raw_frame_with_timestamp(vec![raw], event.timestamp);
-                    process_proxy_raw_frame(
-                        &dropped,
-                        &mut touch_state,
-                        &mut engine,
-                        &mut composer,
-                        sink,
-                        &mut stats,
-                        handler,
-                    )?;
                     stats.input_frame_boundaries += 1;
                     if stopper.observe_frame_boundary(touch_state.is_touch_down()) {
                         stats.idle_drain_frame_boundaries = stopper.extra_frame_boundaries();
@@ -636,6 +723,42 @@ where
     stats.recognizer_events += recognizer_events;
 
     let routed = route_raw_frame(engine, frame).map_err(|err| format!("proxy failed: {err:?}"))?;
+    process_proxy_routed_frame(recognizer_events, composer, sink, stats, routed, handler)
+}
+
+fn process_proxy_resync_contacts<S, H>(
+    contacts: &[ResyncContact],
+    engine: &mut Engine,
+    composer: &mut RawOutputComposer,
+    sink: &mut S,
+    stats: &mut ProxyRuntimeStats,
+    handler: &mut H,
+) -> Result<(), String>
+where
+    S: RawOutputSink,
+    S::Error: std::fmt::Debug,
+    H: GestureHandler,
+{
+    let routed = route_resync_contacts(engine, contacts)
+        .map_err(|err| format!("proxy resync failed: {err:?}"))?;
+    let recognizer_events = routed.passthrough.len();
+    stats.recognizer_events += recognizer_events;
+    process_proxy_routed_frame(recognizer_events, composer, sink, stats, routed, handler)
+}
+
+fn process_proxy_routed_frame<S, H>(
+    recognizer_events: usize,
+    composer: &mut RawOutputComposer,
+    sink: &mut S,
+    stats: &mut ProxyRuntimeStats,
+    routed: crate::raw::RoutedRawFrame,
+    handler: &mut H,
+) -> Result<(), String>
+where
+    S: RawOutputSink,
+    S::Error: std::fmt::Debug,
+    H: GestureHandler,
+{
     let passthrough_events = routed.passthrough.len();
     stats.recognizer_passthrough_events += passthrough_events;
     if passthrough_events > 0 {
@@ -897,6 +1020,7 @@ struct PhysicalTouchState {
     current_slot: i32,
     active_slots: Vec<bool>,
     btn_touch_down: bool,
+    desynchronized: bool,
     capabilities: Capabilities,
 }
 
@@ -907,6 +1031,7 @@ impl PhysicalTouchState {
             current_slot: capabilities.slot_min,
             active_slots: vec![false; slot_count],
             btn_touch_down: false,
+            desynchronized: false,
             capabilities,
         }
     }
@@ -936,7 +1061,26 @@ impl PhysicalTouchState {
     }
 
     fn is_touch_down(&self) -> bool {
-        self.btn_touch_down || self.active_slots.iter().any(|active| *active)
+        self.desynchronized || self.btn_touch_down || self.active_slots.iter().any(|active| *active)
+    }
+
+    fn mark_desynchronized(&mut self) {
+        self.active_slots.fill(false);
+        self.btn_touch_down = false;
+        self.desynchronized = true;
+    }
+
+    fn restore_contacts(&mut self, contacts: &[ResyncContact]) {
+        self.current_slot = self.capabilities.slot_min;
+        self.active_slots.fill(false);
+        self.btn_touch_down = !contacts.is_empty();
+        self.desynchronized = false;
+        for contact in contacts {
+            if let Some(index) = self.slot_index(contact.slot) {
+                self.active_slots[index] = true;
+                self.current_slot = contact.slot;
+            }
+        }
     }
 
     fn slot_index(&self, slot: i32) -> Option<usize> {
@@ -1344,6 +1488,70 @@ mod tests {
     #[test]
     fn physical_touch_snapshot_treats_all_released_slots_as_idle() {
         assert!(!physical_touch_snapshot_is_down(false, &[-1, -1, -1]));
+    }
+
+    #[test]
+    fn syn_dropped_discards_partial_frame_and_ignores_events_until_syn_report() {
+        let mut pending = PendingRawFrame::default();
+        pending.push(ProxyInputEvent {
+            raw: RawEvent::abs_mt_position_x(500),
+            timestamp: None,
+        });
+        let mut resync_pending = false;
+
+        assert_eq!(
+            observe_resync_stream_event(&mut resync_pending, &mut pending, RawEvent::syn_dropped(),),
+            ResyncStreamAction::StartResync
+        );
+        assert!(pending.events.is_empty());
+        assert!(resync_pending);
+        assert_eq!(
+            observe_resync_stream_event(
+                &mut resync_pending,
+                &mut pending,
+                RawEvent::abs_mt_tracking_id(77),
+            ),
+            ResyncStreamAction::Ignore
+        );
+        assert_eq!(
+            observe_resync_stream_event(&mut resync_pending, &mut pending, RawEvent::syn_report(),),
+            ResyncStreamAction::CompleteResync
+        );
+        assert!(!resync_pending);
+    }
+
+    #[test]
+    fn resync_snapshot_keeps_only_active_slots_with_real_slot_numbers() {
+        let contacts = resync_contacts_from_slot_values(
+            Capabilities {
+                slot_min: 2,
+                slot_max: 4,
+                ..test_capabilities()
+            },
+            &[-1, 501, -1],
+            &[10, 20, 30],
+            &[40, 50, 60],
+        );
+
+        assert_eq!(
+            contacts,
+            vec![ResyncContact {
+                slot: 3,
+                tracking_id: 501,
+                x: 20,
+                y: 50,
+            }]
+        );
+    }
+
+    #[test]
+    fn physical_touch_state_stays_busy_until_resync_snapshot_arrives() {
+        let mut state = PhysicalTouchState::new(test_capabilities());
+        state.mark_desynchronized();
+        assert!(state.is_touch_down());
+
+        state.restore_contacts(&[]);
+        assert!(!state.is_touch_down());
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -248,10 +248,23 @@ pub fn run_proxy_with_gesture_handler<H>(
 where
     H: GestureHandler,
 {
+    let mut on_ready = |_device_path: &std::path::Path| Ok(());
+    run_proxy_with_gesture_handler_and_ready(config, handler, &mut on_ready)
+}
+
+pub fn run_proxy_with_gesture_handler_and_ready<H, F>(
+    config: &ProxyRunConfig,
+    handler: &mut H,
+    on_ready: &mut F,
+) -> Result<ProxyRunSummary, String>
+where
+    H: GestureHandler,
+    F: FnMut(&std::path::Path) -> Result<(), String>,
+{
     validate_run_limit(&config.limit)?;
     match config.mode {
         ProxyMode::DryRun => proxy_dry_run(config, handler),
-        ProxyMode::UinputGrab => proxy_uinput_grab(config, handler),
+        ProxyMode::UinputGrab => proxy_uinput_grab(config, handler, on_ready),
     }
 }
 
@@ -294,9 +307,14 @@ where
     })
 }
 
-fn proxy_uinput_grab<H>(config: &ProxyRunConfig, handler: &mut H) -> Result<ProxyRunSummary, String>
+fn proxy_uinput_grab<H, F>(
+    config: &ProxyRunConfig,
+    handler: &mut H,
+    on_ready: &mut F,
+) -> Result<ProxyRunSummary, String>
 where
     H: GestureHandler,
+    F: FnMut(&std::path::Path) -> Result<(), String>,
 {
     let (mut device, capabilities) = open_proxy_device(&config.device_path)?;
     ensure_physical_touchpad_idle_at_start(&config.device_path, &device, capabilities)?;
@@ -313,6 +331,18 @@ where
             config.device_path.display()
         )
     })?;
+    if let Err(ready_err) = on_ready(&config.device_path) {
+        let ungrab_result = device.ungrab().map_err(|err| {
+            format!(
+                "failed to ungrab device {} after readiness failure: {err}",
+                config.device_path.display()
+            )
+        });
+        return match ungrab_result {
+            Ok(()) => Err(ready_err),
+            Err(ungrab_err) => Err(append_additional_error(ready_err, ungrab_err)),
+        };
+    }
     let run_result = run_proxy_loop(
         &mut device,
         ProxyLoopConfig {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use crate::core::{AxisRange, Capabilities, Engine, Event, Gesture, SliderStep, SlotError};
+use crate::core::{
+    AxisRange, Capabilities, Engine, Event, Gesture, ResyncContact, SliderStep, SlotError,
+};
 
 pub const EV_SYN: u16 = 0x00;
 pub const EV_KEY: u16 = 0x01;
@@ -759,6 +761,23 @@ pub fn route_raw_frame(engine: &mut Engine, frame: &RawFrame) -> Result<RoutedRa
         gestures: output.gestures,
         slider_steps: output.slider_steps,
         resync_required: output.resync_required,
+    })
+}
+
+pub fn route_resync_contacts(
+    engine: &mut Engine,
+    contacts: &[ResyncContact],
+) -> Result<RoutedRawFrame, SlotError> {
+    let output = engine.restore_passthrough_contacts(contacts)?;
+    Ok(RoutedRawFrame {
+        passthrough: output
+            .passthrough
+            .into_iter()
+            .filter_map(raw_event_for_core_event)
+            .collect(),
+        gestures: Vec::new(),
+        slider_steps: Vec::new(),
+        resync_required: false,
     })
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -494,7 +494,10 @@ fn property_value<'a>(output: &'a str, key: &str) -> Option<&'a str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{GestureActionConfig, GestureBindingConfig, DEFAULT_TAP_MIN_DURATION_MS};
+    use crate::config::{
+        GestureActionConfig, GestureBindingConfig, DEFAULT_SWIPE_MIN_DISTANCE,
+        DEFAULT_TAP_MIN_DURATION_MS,
+    };
     use crate::core::GestureDirection;
 
     #[test]
@@ -503,6 +506,7 @@ mod tests {
             device: DeviceConfig::Auto,
             edge_width: 0.20,
             tap_min_duration_ms: DEFAULT_TAP_MIN_DURATION_MS,
+            swipe_min_distance: DEFAULT_SWIPE_MIN_DISTANCE,
             gestures: vec![
                 GestureBindingConfig {
                     zone: Zone::Right,
@@ -534,6 +538,7 @@ mod tests {
             device: DeviceConfig::Auto,
             edge_width: 0.10,
             tap_min_duration_ms: DEFAULT_TAP_MIN_DURATION_MS,
+            swipe_min_distance: DEFAULT_SWIPE_MIN_DISTANCE,
             gestures: vec![
                 GestureBindingConfig {
                     zone: Zone::Left,

--- a/src/status.rs
+++ b/src/status.rs
@@ -331,6 +331,7 @@ fn service_status_line(service_name: &str) -> StatusLine {
             let load_state = property_value(&output.stdout, "LoadState").unwrap_or("unknown");
             let active_state = property_value(&output.stdout, "ActiveState").unwrap_or("unknown");
             let sub_state = property_value(&output.stdout, "SubState").unwrap_or("unknown");
+            let detail = service_state_detail(active_state, sub_state, &output.stdout);
 
             if load_state == "not-found" {
                 StatusLine::fail(
@@ -338,14 +339,9 @@ fn service_status_line(service_name: &str) -> StatusLine {
                     format!("{service_name} is not installed"),
                 )
             } else if active_state == "active" {
-                StatusLine::ok(StatusSubject::Service, format!("active ({sub_state})"))
-            } else if active_state == "failed" {
-                StatusLine::fail(StatusSubject::Service, format!("failed ({sub_state})"))
+                StatusLine::ok(StatusSubject::Service, detail)
             } else {
-                StatusLine::fail(
-                    StatusSubject::Service,
-                    format!("{active_state} ({sub_state})"),
-                )
+                StatusLine::fail(StatusSubject::Service, detail)
             }
         }
         Ok(output) => StatusLine::warn(
@@ -372,8 +368,25 @@ fn systemctl_user_show(service_name: &str) -> Result<CommandOutput, String> {
             "ActiveState",
             "-p",
             "SubState",
+            "-p",
+            "MainPID",
+            "-p",
+            "StatusText",
         ],
     )
+}
+
+fn service_state_detail(active_state: &str, sub_state: &str, output: &str) -> String {
+    let mut detail = format!("{active_state} ({sub_state})");
+    if let Some(pid) =
+        property_value(output, "MainPID").filter(|pid| *pid != "0" && !pid.is_empty())
+    {
+        detail.push_str(&format!(", pid {pid}"));
+    }
+    if let Some(status) = property_value(output, "StatusText").filter(|status| !status.is_empty()) {
+        detail.push_str(&format!(", {status}"));
+    }
+    detail
 }
 
 fn command_output(program: &str, args: &[&str]) -> Result<CommandOutput, String> {
@@ -582,7 +595,7 @@ mod tests {
     fn service_status_parses_active_systemd_unit() {
         let output = CommandOutput {
             status_success: true,
-            stdout: "LoadState=loaded\nActiveState=active\nSubState=running\n".to_string(),
+            stdout: "LoadState=loaded\nActiveState=active\nSubState=running\nMainPID=1234\nStatusText=edgepad 0.2.0 ready on /dev/input/event7\n".to_string(),
             stderr: String::new(),
         };
 
@@ -591,5 +604,26 @@ mod tests {
             Some("active")
         );
         assert_eq!(property_value(&output.stdout, "SubState"), Some("running"));
+        assert_eq!(
+            service_state_detail("active", "running", &output.stdout),
+            "active (running), pid 1234, edgepad 0.2.0 ready on /dev/input/event7"
+        );
+    }
+
+    #[test]
+    fn activating_notify_service_is_not_reported_as_running() {
+        let detail = service_state_detail(
+            "activating",
+            "start",
+            "MainPID=4321\nStatusText=waiting for touchpad access\n",
+        );
+        let line = StatusLine::fail(StatusSubject::Service, detail);
+
+        assert_eq!(line.severity, StatusSeverity::Fail);
+        assert_eq!(
+            line.detail,
+            "activating (start), pid 4321, waiting for touchpad access"
+        );
+        assert_eq!(status_result(&[line]), StatusResult::NotRunning);
     }
 }

--- a/tests/core_invariants.rs
+++ b/tests/core_invariants.rs
@@ -176,6 +176,7 @@ fn short_edge_touch_does_not_emit_tap_when_timing_is_known() {
         Vec::new(),
         EngineOptions {
             tap_min_duration: Duration::from_millis(80),
+            ..EngineOptions::default()
         },
     );
 
@@ -210,6 +211,7 @@ fn edge_touch_at_tap_min_duration_emits_tap() {
         Vec::new(),
         EngineOptions {
             tap_min_duration: Duration::from_millis(80),
+            ..EngineOptions::default()
         },
     );
 
@@ -245,6 +247,7 @@ fn zero_tap_min_duration_allows_immediate_tap() {
         Vec::new(),
         EngineOptions {
             tap_min_duration: Duration::ZERO,
+            ..EngineOptions::default()
         },
     );
 
@@ -280,6 +283,7 @@ fn short_edge_swipe_still_emits_directional_gesture() {
         Vec::new(),
         EngineOptions {
             tap_min_duration: Duration::from_millis(80),
+            ..EngineOptions::default()
         },
     );
 
@@ -451,4 +455,64 @@ fn restored_contact_is_passthrough_until_release_even_when_it_is_on_an_edge() {
         vec![Event::slot(1), Event::tracking_id(-1)]
     );
     assert!(released.gestures.is_empty());
+}
+
+#[test]
+fn gesture_distance_is_invariant_across_touchpad_coordinate_ranges() {
+    let direction_for = |x_max: i32, start_x: i32, end_x: i32| {
+        let mut engine = Engine::new(
+            Capabilities {
+                x: AxisRange { min: 0, max: x_max },
+                ..test_caps()
+            },
+            EdgeWidths::all(0.10),
+        );
+        engine
+            .process_frame(&[
+                Event::slot(0),
+                Event::tracking_id(50),
+                Event::x(start_x),
+                Event::y(300),
+            ])
+            .expect("contact should start");
+        engine
+            .process_frame(&[Event::slot(0), Event::x(end_x), Event::y(300)])
+            .expect("contact should move");
+        engine
+            .process_frame(&[Event::slot(0), Event::tracking_id(-1)])
+            .expect("contact should release")
+            .gestures[0]
+            .direction
+    };
+
+    assert_eq!(direction_for(1000, 10, 25), GestureDirection::Tap);
+    assert_eq!(direction_for(2000, 20, 50), GestureDirection::Tap);
+}
+
+#[test]
+fn gesture_direction_compares_normalized_axis_travel() {
+    let mut engine = Engine::new(
+        Capabilities {
+            x: AxisRange { min: 0, max: 2000 },
+            y: AxisRange { min: 0, max: 1000 },
+            ..test_caps()
+        },
+        EdgeWidths::all(0.10),
+    );
+    engine
+        .process_frame(&[
+            Event::slot(0),
+            Event::tracking_id(51),
+            Event::x(20),
+            Event::y(500),
+        ])
+        .expect("contact should start");
+    engine
+        .process_frame(&[Event::slot(0), Event::x(220), Event::y(650)])
+        .expect("contact should move");
+    let released = engine
+        .process_frame(&[Event::slot(0), Event::tracking_id(-1)])
+        .expect("contact should release");
+
+    assert_eq!(released.gestures[0].direction, GestureDirection::Down);
 }

--- a/tests/core_invariants.rs
+++ b/tests/core_invariants.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use edgepad::core::{
     AxisRange, Capabilities, EdgeWidths, Engine, EngineOptions, Event, GestureDirection,
-    SliderAxis, SliderDirection, SliderSpec, SlotError, Zone,
+    ResyncContact, SliderAxis, SliderDirection, SliderSpec, SlotError, Zone,
 };
 
 fn test_caps() -> Capabilities {
@@ -414,4 +414,41 @@ fn syn_dropped_clears_state_and_requires_explicit_resync() {
         .expect("state was cleared after SYN_DROPPED");
 
     assert!(!restarted.resync_required);
+}
+
+#[test]
+fn restored_contact_is_passthrough_until_release_even_when_it_is_on_an_edge() {
+    let mut engine = Engine::new(test_caps(), EdgeWidths::all(0.10));
+    engine
+        .process_frame(&[Event::syn_dropped()])
+        .expect("SYN_DROPPED should reset the engine");
+
+    let restored = engine
+        .restore_passthrough_contacts(&[ResyncContact {
+            slot: 1,
+            tracking_id: 42,
+            x: 20,
+            y: 300,
+        }])
+        .expect("kernel snapshot should restore the active contact");
+
+    assert_eq!(
+        restored.passthrough,
+        vec![
+            Event::slot(1),
+            Event::tracking_id(42),
+            Event::x(20),
+            Event::y(300),
+        ]
+    );
+    assert!(restored.gestures.is_empty());
+
+    let released = engine
+        .process_frame(&[Event::slot(1), Event::tracking_id(-1)])
+        .expect("restored contact release should pass through");
+    assert_eq!(
+        released.passthrough,
+        vec![Event::slot(1), Event::tracking_id(-1)]
+    );
+    assert!(released.gestures.is_empty());
 }

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -41,8 +41,9 @@ fn doctor_cli_checks_config_and_action_executables() {
     );
     assert!(stdout.contains("file"), "stdout was: {stdout}");
     assert!(
-        stdout
-            .contains("device auto, edge width 10.0%, tap min 80ms, 1 gesture binding, 0 sliders"),
+        stdout.contains(
+            "device auto, edge width 10.0%, tap min 80ms, swipe min 2.0%, 1 gesture binding, 0 sliders"
+        ),
         "stdout was: {stdout}"
     );
     assert!(stdout.contains("zones"), "stdout was: {stdout}");

--- a/tests/install_script.rs
+++ b/tests/install_script.rs
@@ -1,0 +1,165 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[test]
+fn install_upgrade_restarts_daemon_and_checks_active_service() {
+    let root = unique_temp_dir("edgepad-install-upgrade");
+    let home = root.join("home");
+    let fake_bin = root.join("bin");
+    let assets = root.join("assets");
+    let log = root.join("commands.log");
+    let udev_rule = root.join("etc/udev/rules.d/70-edgepad.rules");
+    fs::create_dir_all(home.join(".local/bin")).expect("home bin should be created");
+    fs::create_dir_all(home.join(".config/edgepad")).expect("config dir should be created");
+    fs::create_dir_all(home.join(".config/systemd/user"))
+        .expect("systemd user dir should be created");
+    fs::create_dir_all(&fake_bin).expect("fake bin should be created");
+    fs::create_dir_all(&assets).expect("assets should be created");
+
+    write_executable(
+        &fake_bin.join("uname"),
+        "#!/bin/sh\ncase \"$1\" in -s) echo Linux ;; -m) echo x86_64 ;; esac\n",
+    );
+    write_executable(&fake_bin.join("id"), "#!/bin/sh\necho 1000\n");
+    write_executable(
+        &fake_bin.join("curl"),
+        r##"#!/bin/sh
+out=
+url=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) out="$2"; shift 2 ;;
+        *) url="$1"; shift ;;
+    esac
+done
+name="${url##*/}"
+cp "$EDGEPAD_TEST_ASSETS/$name" "$out"
+"##,
+    );
+    write_executable(
+        &fake_bin.join("sudo"),
+        r#"#!/bin/sh
+printf 'sudo %s\n' "$*" >> "$EDGEPAD_TEST_LOG"
+case "$1" in
+    install|rm) command="$1"; shift; exec "$command" "$@" ;;
+    udevadm) exit 0 ;;
+esac
+exit 1
+"#,
+    );
+    write_executable(
+        &fake_bin.join("systemctl"),
+        "#!/bin/sh\nprintf 'systemctl %s\\n' \"$*\" >> \"$EDGEPAD_TEST_LOG\"\n",
+    );
+    write_executable(&fake_bin.join("udevadm"), "#!/bin/sh\nexit 0\n");
+
+    write_executable(
+        &assets.join("edgepad-x86_64-unknown-linux-musl"),
+        "#!/bin/sh\nprintf 'edgepad %s\\n' \"$*\" >> \"$EDGEPAD_TEST_LOG\"\n",
+    );
+    fs::write(assets.join("70-edgepad.rules"), "# test rule\n").expect("rule should be written");
+    fs::write(
+        assets.join("edgepad.service"),
+        "[Service]\nExecStart=%h/.local/bin/edgepad daemon\n",
+    )
+    .expect("service should be written");
+    fs::write(assets.join("edgepad.toml.example"), "device = \"auto\"\n")
+        .expect("config should be written");
+    write_checksums(&assets);
+
+    fs::write(home.join(".local/bin/edgepad"), "old binary\n")
+        .expect("old binary should be present");
+    fs::write(
+        home.join(".config/edgepad/edgepad.toml"),
+        "# existing user config\n",
+    )
+    .expect("existing config should be present");
+    fs::write(
+        home.join(".config/systemd/user/edgepad.service"),
+        "# old service\n",
+    )
+    .expect("old service should be present");
+
+    let path = format!(
+        "{}:{}",
+        fake_bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let output = Command::new("sh")
+        .arg("install.sh")
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("PATH", path)
+        .env("EDGEPAD_TEST_ASSETS", &assets)
+        .env("EDGEPAD_TEST_LOG", &log)
+        .env("EDGEPAD_UDEV_RULE_FILE", &udev_rule)
+        .output()
+        .expect("installer should run");
+
+    assert!(
+        output.status.success(),
+        "installer failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let commands = fs::read_to_string(&log).expect("command log should be readable");
+    assert_ordered(
+        &commands,
+        &[
+            "systemctl --user daemon-reload",
+            "systemctl --user enable edgepad.service",
+            "systemctl --user restart edgepad.service",
+            "systemctl --user is-active --quiet edgepad.service",
+            "edgepad doctor",
+        ],
+    );
+    assert!(home.join(".local/bin/edgepad").is_file());
+    assert!(home.join(".config/systemd/user/edgepad.service").is_file());
+    assert_eq!(
+        fs::read_to_string(home.join(".config/edgepad/edgepad.toml"))
+            .expect("existing config should remain readable"),
+        "# existing user config\n"
+    );
+    assert!(udev_rule.is_file());
+
+    fs::remove_dir_all(root).expect("temp tree should be removed");
+}
+
+fn write_checksums(assets: &Path) {
+    let output = Command::new("sha256sum")
+        .current_dir(assets)
+        .args([
+            "edgepad-x86_64-unknown-linux-musl",
+            "70-edgepad.rules",
+            "edgepad.service",
+            "edgepad.toml.example",
+        ])
+        .output()
+        .expect("sha256sum should run");
+    assert!(output.status.success());
+    fs::write(assets.join("checksums"), output.stdout).expect("checksums should be written");
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("script should be written");
+    let mut permissions = fs::metadata(path)
+        .expect("script metadata should be readable")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("script should be executable");
+}
+
+fn assert_ordered(haystack: &str, needles: &[&str]) {
+    let mut offset = 0;
+    for needle in needles {
+        let relative = haystack[offset..]
+            .find(needle)
+            .unwrap_or_else(|| panic!("missing {needle:?} in command log:\n{haystack}"));
+        offset += relative + needle.len();
+    }
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()))
+}

--- a/tests/raw_routing.rs
+++ b/tests/raw_routing.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
-use edgepad::core::{AxisRange, Capabilities, EdgeWidths, Engine, GestureDirection, Zone};
-use edgepad::raw::{route_raw_frame, RawEvent, RawFrame};
+use edgepad::core::{
+    AxisRange, Capabilities, EdgeWidths, Engine, GestureDirection, ResyncContact, Zone,
+};
+use edgepad::raw::{route_raw_frame, route_resync_contacts, RawEvent, RawFrame};
 
 fn test_engine() -> Engine {
     Engine::new(
@@ -171,4 +173,31 @@ fn route_raw_frame_reports_syn_dropped_without_emitting_raw_passthrough() {
     assert!(routed.passthrough.is_empty());
     assert!(routed.gestures.is_empty());
     assert!(routed.resync_required);
+}
+
+#[test]
+fn route_resync_contacts_rebuilds_kernel_snapshot_as_passthrough() {
+    let mut engine = test_engine();
+    let routed = route_resync_contacts(
+        &mut engine,
+        &[ResyncContact {
+            slot: 1,
+            tracking_id: 200,
+            x: 20,
+            y: 300,
+        }],
+    )
+    .expect("resync snapshot should route");
+
+    assert_eq!(
+        routed.passthrough,
+        vec![
+            RawEvent::abs_mt_slot(1),
+            RawEvent::abs_mt_tracking_id(200),
+            RawEvent::abs_mt_position_x(20),
+            RawEvent::abs_mt_position_y(300),
+        ]
+    );
+    assert!(routed.gestures.is_empty());
+    assert!(!routed.resync_required);
 }

--- a/tests/release_artifacts.rs
+++ b/tests/release_artifacts.rs
@@ -83,7 +83,7 @@ fn release_workflow_publishes_required_assets_and_checksums() {
     let workflow = include_str!("../.github/workflows/release.yml");
 
     for required in [
-        "edgepad-x86_64-unknown-linux-gnu",
+        "edgepad-x86_64-unknown-linux-musl",
         "70-edgepad.rules",
         "edgepad.service",
         "edgepad.toml.example",
@@ -92,6 +92,10 @@ fn release_workflow_publishes_required_assets_and_checksums() {
         "v$PACKAGE_VERSION",
         "gh release create",
         "--generate-notes",
+        "targets: x86_64-unknown-linux-musl",
+        "--target x86_64-unknown-linux-musl",
+        "readelf -l",
+        "INTERP",
     ] {
         assert!(
             workflow.contains(required),

--- a/tests/release_artifacts.rs
+++ b/tests/release_artifacts.rs
@@ -106,3 +106,11 @@ fn release_workflow_publishes_required_assets_and_checksums() {
         );
     }
 }
+
+#[test]
+fn ci_uses_the_locked_dependency_graph_for_rust_checks() {
+    let workflow = include_str!("../.github/workflows/ci.yml");
+
+    assert!(workflow.contains("cargo clippy --locked --all-targets -- -D warnings"));
+    assert!(workflow.contains("cargo test --locked"));
+}

--- a/tests/release_artifacts.rs
+++ b/tests/release_artifacts.rs
@@ -76,6 +76,9 @@ fn release_user_service_runs_installed_user_binary_with_config() {
     );
     assert!(service.contains("WantedBy=default.target"));
     assert!(service.contains("Restart=on-failure"));
+    assert!(service.contains("Type=notify"));
+    assert!(service.contains("NotifyAccess=main"));
+    assert!(service.contains("TimeoutStartSec=45s"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Prepare edgepad v0.2.1 for release.

## Highlights

- Resync active multitouch contacts after `SYN_DROPPED` without claiming an in-progress edge contact.
- Normalize gesture distance across touchpad coordinate ranges.
- Ship a portable static musl release binary.
- Restart the daemon after installer upgrades and verify that it is active.
- Report daemon readiness through systemd after the virtual touchpad is ready.
- Require the locked Cargo dependency graph in CI.
