### PR TITLE
Finalize v0.2.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "edgepad"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "evdev",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgepad"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Touchpad edge gestures for Linux/Wayland"


### PR DESCRIPTION
## Summary

Finalize edgepad v0.2.1 release metadata.

## Highlights

- Bump the package version to 0.2.1.
- Keep the Cargo manifest and lockfile version in sync.
