### PR TITLE
Improve installation and onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ The hard part is input correctness: Type-B multitouch slots, mixed edge/center c
 - Bounded live proxy mode for testing real hardware.
 - Nix package, NixOS module, Home Manager module, release installer, and systemd user service.
 
+## Core concepts
+
+The touchpad is split into four edge zones: `left`, `right`, `top`, and `bottom`.
+
+- A **gesture** runs one action when the finger lifts. It can match either a directional swipe or a
+  tap.
+- A **tap** is a gesture with no meaningful movement.
+- A **slider** runs repeated steps while the finger moves, which is useful for volume or brightness.
+- An **action** is the command that edgepad starts for a gesture or slider step.
+
+A slider and a tap gesture can share the same edge. A slider and a directional gesture cannot,
+because both would need to own the same movement.
+
 ## Install
 
 ### Release installer
@@ -32,9 +45,17 @@ Preview the install plan first:
 curl -fsSL https://raw.githubusercontent.com/assembledev/edgepad/main/install.sh | sh -s -- --dry-run
 ```
 
-The installer downloads a statically linked x86_64 Linux release binary, installs udev rules, writes a default config to `~/.config/edgepad/edgepad.toml`, installs a systemd user service, starts it, and runs `edgepad doctor`.
-Running the installer again upgrades the installed files and restarts the active daemon before
-checking its health.
+The release installer is the complete setup for an x86_64 Linux desktop with systemd. It downloads
+a static binary, installs the udev rules, writes a default config to
+`~/.config/edgepad/edgepad.toml`, installs and starts the user service, then runs `edgepad doctor`.
+It asks for `sudo` only when installing the udev rules.
+
+### Update
+
+Run the same installer command again. It keeps your config, replaces the installed files, restarts
+the daemon, and checks that the service is healthy.
+
+### Uninstall
 
 Uninstall files created by the release installer:
 
@@ -50,6 +71,12 @@ curl -fsSL https://raw.githubusercontent.com/assembledev/edgepad/main/install.sh
 
 ### Nix
 
+For normal desktop use, install both the NixOS module and the Home Manager module. The NixOS module
+provides device access; the Home Manager module owns the config and user service. See the complete
+[Nix setup](docs/nix.md).
+
+The commands below only build or run the package. They do not install device rules or a user service.
+
 Build and run from the repository:
 
 ```bash
@@ -64,33 +91,13 @@ nix run github:assembledev/edgepad -- --help
 nix run github:assembledev/edgepad -- devices
 ```
 
-Development shell:
-
-```bash
-nix develop
-cargo test
-```
-
-See [Nix](docs/nix.md) for flake outputs, NixOS, and Home Manager setup.
-
-### Cargo
-
-```bash
-cargo install --git https://github.com/assembledev/edgepad
-```
-
-For local development:
-
-```bash
-cargo fmt --check
-cargo clippy --all-targets -- -D warnings
-cargo test
-cargo run -- --help
-```
-
 ## Quick start
 
-Check the current daemon, config, device, zones, and actions:
+The config installed by the release script uses desktop notifications as safe example actions.
+Gestures will show what they matched, but they will not change your volume, brightness, media state,
+or workspace until you replace those commands.
+
+Check that the service, config, and touchpad are ready:
 
 ```bash
 edgepad status
@@ -100,16 +107,10 @@ The service becomes active only after the virtual touchpad is created and the ph
 grabbed. Status output includes the ready daemon's PID, version, and selected device when systemd
 provides them.
 
-Run deeper diagnostics for device access, action executables, and service state:
+If status reports a problem, run the full check:
 
 ```bash
 edgepad doctor
-```
-
-List touchpad candidates:
-
-```bash
-edgepad devices
 ```
 
 Edit your config:
@@ -152,6 +153,18 @@ Watch logs:
 
 ```bash
 journalctl --user -u edgepad.service -f
+```
+
+If pointer input behaves incorrectly, stop edgepad immediately:
+
+```bash
+systemctl --user stop edgepad.service
+```
+
+The physical touchpad is ungrabbed when the daemon stops. Start it again with:
+
+```bash
+systemctl --user start edgepad.service
 ```
 
 For a foreground run, `edgepad daemon` reads `~/.config/edgepad/edgepad.toml` by default.
@@ -253,6 +266,28 @@ The preferred desktop setup is a user service with logind/uaccess ACLs. The NixO
 
 Manual commands that read real input devices may need `sudo`, the `input` group, or active seat ACLs. Use `edgepad doctor` to see what your system is missing.
 
+## Troubleshooting
+
+Start with these two commands:
+
+```bash
+edgepad status
+edgepad doctor
+```
+
+Common problems:
+
+- **More than one touchpad was found:** run `edgepad devices`, then set an explicit
+  `device = "/dev/input/eventX"` in the config.
+- **The touchpad or `/dev/uinput` is not accessible:** use the access fix reported by
+  `edgepad doctor`. If udev rules or group membership just changed, start a new login session.
+- **The service stays in `activating`:** edgepad is still waiting for a readable touchpad or
+  `/dev/uinput`. Check `edgepad doctor` and the service log.
+- **An action command is missing:** install that program, use its full path, or replace the example
+  action with a command available on your desktop.
+- **Pointer input is wrong:** stop the service with `systemctl --user stop edgepad.service`, then
+  inspect `journalctl --user -u edgepad.service -b`.
+
 ## Diagnostics and capture
 
 Device discovery is read-only:
@@ -284,6 +319,9 @@ edgepad proxy --device /dev/input/eventX --frames 300 --dry-run
 
 Run a bounded live virtual-touchpad proxy test:
 
+This command grabs the physical touchpad for the duration of the test. Normal pointer input is sent
+through edgepad's temporary virtual touchpad until the frame limit is reached.
+
 ```bash
 edgepad proxy --device /dev/input/eventX --frames 300 --uinput --grab
 ```
@@ -310,6 +348,25 @@ edgepad replay-raw  Replay a raw evdev capture through routing and output compos
 - [Passthrough and uinput](docs/passthrough-uinput.md)
 - [Replay fixture format](docs/replay-format.md)
 - [Nix](docs/nix.md)
+
+## Development
+
+Clone the repository and enter its development shell:
+
+```bash
+git clone https://github.com/assembledev/edgepad.git
+cd edgepad
+nix develop
+```
+
+Build and check the project from there:
+
+```bash
+cargo build --locked
+cargo fmt --check
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked
+```
 
 ## Contributing
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -1,58 +1,54 @@
 # Nix
 
-`edgepad` ships a Nix flake for local builds, development shells, NixOS device access, and a Home Manager user service.
+`edgepad` provides two modules for a normal desktop installation:
 
-The flake uses `rust-overlay` for an explicit Rust toolchain, reads the package version from `Cargo.toml`, and keeps the package definition in `nix/package.nix`.
+- the NixOS module installs the package, loads `uinput`, and grants device access;
+- the Home Manager module writes the config and runs edgepad as a user service.
 
-## Build and run
+Use both modules for the complete setup. Building the package alone does not configure device access
+or start the daemon.
 
-```bash
-nix build .#edgepad
-./result/bin/edgepad --help
-```
+## Normal desktop installation
 
-Run commands without installing:
+### 1. Add the flake input
 
-```bash
-nix run .#edgepad -- devices
-nix run .#edgepad -- doctor
-nix run .#edgepad -- replay tests/fixtures/left-edge-swipe-right.ev
-```
-
-For read-only capture from `/dev/input/event*`, permissions may require `sudo`, group access, or active seat ACLs:
-
-```bash
-sudo ./result/bin/edgepad devices
-sudo ./result/bin/edgepad dump --device /dev/input/eventX --out bug.ev --frames 300
-./result/bin/edgepad replay bug.ev
-```
-
-For live diagnostics:
-
-```bash
-sudo ./result/bin/edgepad proxy --device /dev/input/eventX --frames 300 --dry-run
-sudo ./result/bin/edgepad proxy --device /dev/input/eventX --frames 300 --uinput --grab
-```
-
-For normal desktop gesture use, prefer the NixOS + Home Manager modules below. They run the daemon as a user service instead of a root shell command.
-
-## NixOS module
-
-The NixOS module prepares system access. It installs the package, loads `uinput`, and installs udev rules for the touchpad event node and `/dev/uinput`.
+Add edgepad to the inputs of your system flake:
 
 ```nix
 {
-  imports = [ inputs.edgepad.nixosModules.default ];
-
-  services.edgepad = {
-    enable = true;
+  inputs.edgepad = {
+    url = "github:assembledev/edgepad";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 }
 ```
 
-The default access mode uses systemd-logind seat ACLs through `TAG+="uaccess"`. This is the preferred desktop mode because the active local user gets device access without permanent membership in the `input` group.
+The examples below use `inputs` in NixOS and Home Manager modules. If your flake does not already
+pass it to modules, use:
 
-For systems without a normal local seat/logind session, use the group fallback:
+- `specialArgs = { inherit inputs; };` in `nixosSystem`;
+- `extraSpecialArgs = { inherit inputs; };` in a standalone `homeManagerConfiguration`; or
+- `home-manager.extraSpecialArgs = { inherit inputs; };` when Home Manager is a NixOS module.
+
+### 2. Enable system access
+
+Import the NixOS module in your system configuration:
+
+```nix
+{ inputs, ... }:
+
+{
+  imports = [ inputs.edgepad.nixosModules.default ];
+
+  services.edgepad.enable = true;
+}
+```
+
+The default access mode uses systemd-logind seat ACLs through `TAG+="uaccess"`. The active local
+user gets access to the touchpad and `/dev/uinput` without permanent membership in the `input`
+group.
+
+For a machine without a normal local seat or logind session, use the group fallback:
 
 ```nix
 {
@@ -64,13 +60,15 @@ For systems without a normal local seat/logind session, use the group fallback:
 }
 ```
 
-After adding a user to the input group, start a new login session before expecting group membership to be visible.
+Start a new login session after adding a user to the group.
 
-## Home Manager module
+### 3. Configure the user service
 
-The Home Manager module writes `~/.config/edgepad/edgepad.toml` and starts a systemd user service bound to `graphical-session.target`.
+Import the Home Manager module in your home configuration:
 
 ```nix
+{ inputs, pkgs, ... }:
+
 {
   imports = [ inputs.edgepad.homeManagerModules.default ];
 
@@ -85,59 +83,143 @@ The Home Manager module writes `~/.config/edgepad/edgepad.toml` and starts a sys
       {
         zone = "top";
         direction = "tap";
-        action = [ "notify-send" "edgepad" "play-pause" ];
+        action = [ "${pkgs.libnotify}/bin/notify-send" "edgepad" "play-pause" ];
       }
     ];
 
     sliders = [
       {
         zone = "right";
-        up = [ "notify-send" "edgepad" "brightness-up" ];
-        down = [ "notify-send" "edgepad" "brightness-down" ];
+        up = [ "${pkgs.libnotify}/bin/notify-send" "edgepad" "brightness-up" ];
+        down = [ "${pkgs.libnotify}/bin/notify-send" "edgepad" "brightness-down" ];
       }
     ];
   };
 }
 ```
 
-Gesture and slider actions are argv arrays and are not run through a shell. Use full paths or add packages to the user environment when you do not want to rely on `PATH`.
+These notification actions are safe examples. Replace them with the commands used by your desktop.
+Actions are argv arrays and are not run through a shell. Using package paths, as above, avoids
+depending on the service's `PATH`.
+
+### 4. Apply and verify
+
+Apply the NixOS and Home Manager configurations using your normal rebuild commands. If Home Manager
+is integrated into the NixOS configuration, the NixOS rebuild applies both modules.
+
+Then check the user service:
+
+```bash
+edgepad status
+edgepad doctor
+systemctl --user status edgepad.service
+```
+
+The service is ready only after edgepad has created the virtual touchpad and grabbed the physical
+device. If pointer input behaves incorrectly, stop it immediately:
+
+```bash
+systemctl --user stop edgepad.service
+```
+
+### Update
+
+Update the locked edgepad input, then apply your system and Home Manager configurations again:
+
+```bash
+nix flake update edgepad
+```
 
 ## Device selection
 
-`device = "auto"` scans readable `/dev/input/event*` nodes and succeeds only when exactly one touchpad candidate is present. If there are multiple candidates, list them:
+`device = "auto"` succeeds only when exactly one readable touchpad candidate is present. If edgepad
+finds more than one candidate, list them:
 
 ```bash
 edgepad devices
 ```
 
-and configure the explicit path:
+Then set the chosen event node in Home Manager:
 
 ```nix
 services.edgepad.device = "/dev/input/event7";
 ```
+
+## Package-only use
+
+Build the package from a checkout:
+
+```bash
+nix build .#edgepad
+./result/bin/edgepad --help
+```
+
+Run a command without installing:
+
+```bash
+nix run .#edgepad -- devices
+nix run .#edgepad -- replay tests/fixtures/left-edge-swipe-right.ev
+```
+
+From outside the repository, use the GitHub flake:
+
+```bash
+nix run github:assembledev/edgepad -- --help
+```
+
+These commands provide the binary only. For the daemon, device rules, and user service, use the two
+modules above.
 
 ## Development shell
 
 ```bash
 nix develop
 cargo fmt --check
-cargo clippy --all-targets -- -D warnings
-cargo test
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked
 ```
 
 Or run one command inside the shell:
 
 ```bash
-nix develop -c cargo test
+nix develop -c cargo test --locked
 ```
 
-The dev shell includes stable Rust from `rust-overlay`, `rust-src`, `rust-analyzer`, `clippy`, `rustfmt`, `evtest`, and `libinput`.
+The shell includes stable Rust, `rust-src`, `rust-analyzer`, `clippy`, `rustfmt`, `evtest`, and
+`libinput`.
 
-For direnv:
+The repository includes an `.envrc`, so direnv users can run:
 
 ```bash
 direnv allow
 ```
+
+## Manual diagnostics
+
+Read-only device discovery and capture may require `sudo` when the current shell does not have a
+seat ACL:
+
+```bash
+sudo ./result/bin/edgepad devices
+sudo ./result/bin/edgepad dump --device /dev/input/eventX --out bug.ev --frames 300
+./result/bin/edgepad replay bug.ev
+```
+
+Dry-run proxy mode reads and routes events without grabbing the touchpad:
+
+```bash
+sudo ./result/bin/edgepad proxy --device /dev/input/eventX --frames 300 --dry-run
+```
+
+The live proxy below grabs the physical touchpad and sends normal pointer input through a temporary
+virtual touchpad until the frame limit is reached:
+
+```bash
+sudo ./result/bin/edgepad proxy --device /dev/input/eventX --frames 300 --uinput --grab
+```
+
+For normal desktop use, run the Home Manager service instead of a root shell command. Gesture
+actions started under `sudo` inherit root's environment, not the graphical user session.
 
 ## Flake outputs
 

--- a/docs/passthrough-uinput.md
+++ b/docs/passthrough-uinput.md
@@ -65,6 +65,9 @@ For normal desktop use, run the daemon as a user service with access to `/dev/in
 
 ## Config example
 
+The commands below are safe notification examples. Replace them with the commands used by your
+desktop.
+
 ```toml
 device = "auto"
 edge_width = 0.10

--- a/examples/edgepad.toml.example
+++ b/examples/edgepad.toml.example
@@ -1,3 +1,6 @@
+# Safe example actions: these commands only show notifications.
+# Replace them with the volume, brightness, media, and workspace commands used by your desktop.
+
 device = "auto"
 edge_width = 0.10
 tap_min_duration_ms = 80


### PR DESCRIPTION
## Summary

Make the edgepad documentation follow the path a new user actually takes.

## Highlights

- Explain edge zones, gestures, taps, sliders, and actions before showing configuration.
- Present the complete release and Nix installation paths before package-only and diagnostic commands.
- Add a copyable NixOS and Home Manager setup with verification and update steps.
- Clarify that the shipped notification actions are safe examples, not real desktop controls.
- Add an emergency stop command and a short troubleshooting path near the quick start.
- Warn before commands that grab the physical touchpad.
- Remove `cargo install`, which does not provide a functional edgepad setup.
