### PR TITLE
Release v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "edgepad"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "evdev",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgepad"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Touchpad edge gestures for Linux/Wayland"


### PR DESCRIPTION
## Summary

Prepare edgepad v0.2.2 by synchronizing the Cargo package and lockfile versions.

The functional changes are already in main through #8: config-aware diagnostics, timestamped replay captures, physical touchpad button passthrough, and clickpad click/click-drag handling inside configured edge zones.

## Validation

- cargo fmt --check
- cargo clippy --locked --all-targets -- -D warnings
- cargo test --locked
- cargo build --release --locked
- nix flake check
- nix flake check --all-systems --no-build
- nix build .#edgepad
- installer install/uninstall dry-runs
- actionlint

After this PR is merged, the main merge commit will be tagged v0.2.2 and the release workflow will publish the release assets.