### PR TITLE
Release v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "edgepad"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "evdev",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgepad"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Touchpad edge gestures for Linux/Wayland"

--- a/README.md
+++ b/README.md
@@ -308,14 +308,14 @@ edgepad devices --all
 Capture recognizer-level events from a real touchpad:
 
 ```bash
-edgepad dump --device /dev/input/eventX --out bug.ev --frames 300
+edgepad dump --device auto --out bug.ev --frames 300
 edgepad replay bug.ev
 ```
 
 Capture raw evdev events for passthrough/output debugging:
 
 ```bash
-edgepad dump --raw --device /dev/input/eventX --out bug.raw.ev --frames 300
+edgepad dump --raw --device auto --out bug.raw.ev --frames 300
 edgepad replay-raw bug.raw.ev
 ```
 
@@ -334,7 +334,9 @@ through edgepad's temporary virtual touchpad until the frame limit is reached.
 edgepad proxy --device /dev/input/eventX --frames 300 --uinput --grab
 ```
 
-Replace `/dev/input/eventX` with the touchpad node reported by `edgepad devices`. If the OS denies access to the event node or `/dev/uinput`, run `edgepad doctor` and use the access model it reports for your system.
+If auto-detection finds multiple touchpads, use the event node reported by `edgepad devices`. If the
+OS denies access to the event node or `/dev/uinput`, run `edgepad doctor` and use the access model it
+reports for your system.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Example config:
 ```toml
 device = "auto"
 edge_width = 0.10
-tap_min_duration_ms = 80
+tap_min_duration_ms = 40
 swipe_min_distance = 0.02
 
 [[sliders]]
@@ -184,10 +184,10 @@ device = "auto"
 edge_width = 0.10
 ```
 
-`tap_min_duration_ms` ignores very short edge taps. It defaults to `80`; set it to `0` to disable the guard.
+`tap_min_duration_ms` ignores very short edge taps. It defaults to `40`; set it to `0` to disable the guard.
 
 ```toml
-tap_min_duration_ms = 80
+tap_min_duration_ms = 40
 ```
 
 `swipe_min_distance` is the minimum normalized touchpad travel that turns an edge contact into a

--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ edgepad dump --device auto --out bug.ev --frames 300
 edgepad replay bug.ev
 ```
 
+Stop `edgepad.service` before capture: the running daemon holds the physical touchpad with
+`EVIOCGRAB`, so another reader receives no events. `dump` warns after three seconds without input
+but never stops the service automatically. If input arrives later, it confirms that capture has
+started and records it normally.
+
 Capture raw evdev events for passthrough/output debugging:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ edgepad dump --device auto --out bug.ev --frames 300
 edgepad replay bug.ev
 ```
 
+The frame count is a minimum capture budget. If it is reached while a finger is down, dump asks you
+to release all contacts and records their release frames before exiting.
+
 Stop `edgepad.service` before capture: the running daemon holds the physical touchpad with
 `EVIOCGRAB`, so another reader receives no events. `dump` warns after three seconds without input
 but never stops the service automatically. If input arrives later, it confirms that capture has

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The touchpad is split into four edge zones: `left`, `right`, `top`, and `bottom`
 
 - A **gesture** runs one action when the finger lifts. It can match either a directional swipe or a
   tap.
-- A **tap** is a gesture with no meaningful movement.
+- A **tap** is a gesture whose contact never leaves the configured movement tolerance.
 - A **slider** runs repeated steps while the finger moves, which is useful for volume or brightness.
 - An **action** is the command that edgepad starts for a gesture or slider step.
 
@@ -193,6 +193,9 @@ tap_min_duration_ms = 80
 `swipe_min_distance` is the minimum normalized touchpad travel that turns an edge contact into a
 directional gesture. It defaults to `0.02`, or 2% of the corresponding touchpad axis. Smaller
 movement remains a tap, so the same physical gesture behaves consistently across coordinate ranges.
+Once a contact reaches this distance it no longer qualifies as a tap, even if it returns to its
+starting point. A slider contact that emits any steps is also consumed by the slider and does not
+emit an additional tap when released.
 
 ```toml
 swipe_min_distance = 0.02

--- a/docs/device-discovery.md
+++ b/docs/device-discovery.md
@@ -23,9 +23,11 @@ edgepad devices --all
 For tests/debugging, the input root can be overridden:
 
 ```bash
-edgepad devices --root /tmp/fake-input-root
-edgepad devices --root /tmp/fake-input-root --all
+edgepad devices --input-root /tmp/fake-input-root
+edgepad devices --input-root /tmp/fake-input-root --all
 ```
+
+`--root` remains available as an alias for compatibility.
 
 ## Permissions
 
@@ -48,6 +50,8 @@ This command is read-only:
 
 ## Rationale
 
-Before `edgepad dump --device ... --out bug.ev`, users need a way to identify the correct touchpad event node without guessing.
+Auto-selection in `edgepad dump --device auto` and `daemon --device auto` uses these same discovery
+rules. When multiple candidates are present, use `edgepad devices` and pass the chosen path
+explicitly.
 
-`daemon --device auto` uses the same discovery rules and starts only when exactly one readable touchpad candidate is found. If multiple candidates are present, use `edgepad devices` and pass the chosen path explicitly.
+Auto-selection succeeds only when exactly one readable touchpad candidate is found.

--- a/docs/dump-capture.md
+++ b/docs/dump-capture.md
@@ -16,6 +16,25 @@ edgepad devices --all
 
 Reading `/dev/input/event*` may require `sudo`, the `input` group, or seat/logind ACLs.
 
+## Running daemon
+
+The live edgepad daemon holds the physical touchpad with `EVIOCGRAB`, so a separate `edgepad dump`
+process cannot receive physical events while `edgepad.service` is running. Stop the service before
+capturing and start it again afterward:
+
+```bash
+(
+  systemctl --user stop edgepad.service
+  trap 'systemctl --user start edgepad.service' EXIT
+  edgepad dump --device auto --out bug.ev --frames 300
+)
+```
+
+`dump` never stops the service or probes the device with `EVIOCGRAB`. It prints the selected device
+and waits normally; if no input arrives within three seconds, it warns that the device may be
+grabbed and continues waiting. If input arrives later, it confirms that capture has started and
+writes the events normally.
+
 ## Recognition profile
 
 `edgepad replay`, `edgepad replay-raw`, and `edgepad proxy` use the default user config unless

--- a/docs/dump-capture.md
+++ b/docs/dump-capture.md
@@ -87,7 +87,9 @@ Unknown event types and codes are kept with numeric fallback instead of being si
 
 ## Frame limits
 
-With `--frames N`, capture stops after N frame boundaries (`SYN_REPORT` or `SYN_DROPPED`) and prints a summary:
+With `--frames N`, capture records at least N frame boundaries (`SYN_REPORT` or `SYN_DROPPED`).
+If the budget is reached while a contact is active, dump asks you to release all contacts and keeps
+recording through the release frame before it prints the summary:
 
 - output path;
 - device path;
@@ -101,9 +103,10 @@ For frame-limited edge gesture captures, a useful flow is:
 1. start capture;
 2. perform the edge or mixed gesture;
 3. release the gesture finger;
-4. place a finger in the center until the frame budget finishes.
+4. if dump is still below its frame budget, move a finger in the center to produce more frames;
+5. when dump reports that the frame budget was reached, release all contacts.
 
-That captures the gesture release while keeping the event stream active. Without `--frames`, stop capture manually with Ctrl+C after reproducing the gesture.
+Without `--frames`, stop capture manually with Ctrl+C after reproducing the gesture.
 
 ## Capability metadata
 

--- a/docs/dump-capture.md
+++ b/docs/dump-capture.md
@@ -31,18 +31,19 @@ Dump files include the kernel timestamp on every frame boundary, so replay appli
 Replay-format capture keeps the Type-B multitouch events used by the recognizer:
 
 ```bash
-edgepad dump --device /dev/input/event5 --out bug.ev --frames 300
+edgepad dump --device auto --out bug.ev --frames 300
 edgepad replay bug.ev
 ```
 
 The output uses the same text fixture format as the replay tests. A useful bug capture can be copied into `tests/fixtures/` and promoted into a regression test.
+If auto-detection finds multiple touchpads, use the event node reported by `edgepad devices`.
 
 ## Raw capture
 
 Raw capture keeps the evdev event shape needed for passthrough and virtual touchpad output:
 
 ```bash
-edgepad dump --raw --device /dev/input/event5 --out bug.raw.ev --frames 300
+edgepad dump --raw --device auto --out bug.raw.ev --frames 300
 edgepad replay-raw bug.raw.ev
 ```
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -76,7 +76,7 @@ Import the Home Manager module in your home configuration:
     enable = true;
     device = "auto";
     edgeWidth = 0.10;
-    tapMinDurationMs = 80;
+    tapMinDurationMs = 40;
     swipeMinDistance = 0.02;
 
     gestures = [

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -201,7 +201,7 @@ seat ACL:
 
 ```bash
 sudo ./result/bin/edgepad devices
-sudo ./result/bin/edgepad dump --device /dev/input/eventX --out bug.ev --frames 300
+sudo ./result/bin/edgepad dump --device auto --out bug.ev --frames 300
 ./result/bin/edgepad replay bug.ev
 ```
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -205,6 +205,10 @@ sudo ./result/bin/edgepad dump --device auto --out bug.ev --frames 300
 ./result/bin/edgepad replay bug.ev
 ```
 
+Stop `edgepad.service` before running `dump`; the daemon's `EVIOCGRAB` prevents a separate process
+from receiving physical events. `dump` warns when no events arrive but does not stop or restart the
+service.
+
 Dry-run proxy mode reads and routes events without grabbing the touchpad:
 
 ```bash

--- a/docs/passthrough-uinput.md
+++ b/docs/passthrough-uinput.md
@@ -76,7 +76,7 @@ desktop.
 ```toml
 device = "auto"
 edge_width = 0.10
-tap_min_duration_ms = 80
+tap_min_duration_ms = 40
 swipe_min_distance = 0.02
 
 [[gestures]]

--- a/docs/replay-format.md
+++ b/docs/replay-format.md
@@ -173,7 +173,9 @@ resync_required: false
 
 If the raw capture ends with an active passthrough contact, output composition includes a final synthetic release frame so replay inspection matches the bounded live proxy cleanup behavior.
 
-The summary also prints lightweight capture diagnostics. With pure `--frames N`, a capture can end with an active center contact because the frame budget stopped mid-contact. For edge gesture captures, a useful workflow is to perform the gesture, release it, then place a finger in the center until `--frames` finishes.
+The summary also prints lightweight capture diagnostics. `edgepad dump --frames N` treats N as a
+minimum budget and, when necessary, records additional frames until every physical contact is
+released. A fixture that still ends with an active contact is reported as incomplete or truncated.
 
 This is a debug/demo helper, not a replacement for `cargo test`. Fixtures without metadata use default ranges; captures produced by `edgepad dump` include real device ranges and replay uses those instead.
 

--- a/examples/edgepad.toml.example
+++ b/examples/edgepad.toml.example
@@ -3,7 +3,7 @@
 
 device = "auto"
 edge_width = 0.10
-tap_min_duration_ms = 80
+tap_min_duration_ms = 40
 swipe_min_distance = 0.02
 
 [[sliders]]

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -144,7 +144,7 @@ in
 
     tapMinDurationMs = lib.mkOption {
       type = lib.types.ints.between 0 10000;
-      default = 80;
+      default = 40;
       description = "Minimum edge contact duration in milliseconds required for a tap gesture.";
     };
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,10 @@
 use std::fs;
 use std::io;
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
+use evdev::raw_stream::RawDevice;
 use evdev::{AbsoluteAxisCode, Device, PropType};
 
 use crate::uinput::DEFAULT_VIRTUAL_TOUCHPAD_NAME;
@@ -110,6 +113,40 @@ pub fn discover_device_report(input_root: &Path) -> io::Result<DiscoveryReport> 
     })
 }
 
+pub fn wait_for_raw_device_events(device: &RawDevice, timeout: Duration) -> io::Result<bool> {
+    wait_for_fd_readable(device.as_raw_fd(), timeout)
+}
+
+fn wait_for_fd_readable(fd: RawFd, timeout: Duration) -> io::Result<bool> {
+    let mut poll_fd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let timeout_ms = poll_timeout_ms(timeout);
+
+    loop {
+        let result = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
+        if result >= 0 {
+            return Ok(result > 0);
+        }
+
+        let err = io::Error::last_os_error();
+        if err.kind() != io::ErrorKind::Interrupted {
+            return Err(err);
+        }
+    }
+}
+
+fn poll_timeout_ms(timeout: Duration) -> i32 {
+    let millis = timeout.as_millis();
+    if millis == 0 {
+        0
+    } else {
+        millis.min(i32::MAX as u128) as i32
+    }
+}
+
 pub fn touchpad_candidates(summaries: &[DeviceSummary]) -> Vec<&DeviceSummary> {
     summaries
         .iter()
@@ -203,5 +240,31 @@ fn format_axis(axis: Option<AxisInfo>) -> String {
     match axis {
         Some(axis) => format!("{}..={}", axis.min, axis.max),
         None => "n/a".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::UnixStream;
+
+    use super::*;
+
+    #[test]
+    fn wait_for_fd_readable_reports_timeout_and_ready_data() {
+        let (reader, mut writer) = UnixStream::pair().expect("socket pair should be created");
+
+        assert!(!wait_for_fd_readable(reader.as_raw_fd(), Duration::ZERO)
+            .expect("empty socket should be polled"));
+
+        writer
+            .write_all(b"x")
+            .expect("socket should accept test data");
+
+        assert!(
+            wait_for_fd_readable(reader.as_raw_fd(), Duration::from_millis(100))
+                .expect("readable socket should be polled")
+        );
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -5,9 +5,13 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use evdev::raw_stream::RawDevice;
-use evdev::{AbsoluteAxisCode, Device, PropType};
+use evdev::{AbsoluteAxisCode, Device, KeyCode, PropType};
 
+use crate::core::Capabilities;
+use crate::raw::ABS_MT_TRACKING_ID;
 use crate::uinput::DEFAULT_VIRTUAL_TOUCHPAD_NAME;
+
+nix::ioctl_read_buf!(eviocgmtslots, b'E', 0x0a, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AxisInfo {
@@ -115,6 +119,41 @@ pub fn discover_device_report(input_root: &Path) -> io::Result<DiscoveryReport> 
 
 pub fn wait_for_raw_device_events(device: &RawDevice, timeout: Duration) -> io::Result<bool> {
     wait_for_fd_readable(device.as_raw_fd(), timeout)
+}
+
+pub fn physical_touch_is_down(
+    device: &RawDevice,
+    capabilities: Option<Capabilities>,
+) -> io::Result<bool> {
+    let key_state = device.get_key_state()?;
+    let btn_touch_down = key_state.contains(KeyCode::BTN_TOUCH);
+    let Some(capabilities) = capabilities else {
+        return Ok(btn_touch_down);
+    };
+    let tracking_ids = mt_slot_values(device, capabilities, ABS_MT_TRACKING_ID)?;
+    Ok(touch_snapshot_is_down(btn_touch_down, &tracking_ids))
+}
+
+pub fn mt_slot_values(
+    device: &RawDevice,
+    capabilities: Capabilities,
+    axis_code: u16,
+) -> io::Result<Vec<i32>> {
+    let slot_count = (capabilities.slot_max - capabilities.slot_min + 1) as usize;
+    let mut request = vec![0_i32; slot_count + 1];
+    request[0] = axis_code as i32;
+    let request_bytes = unsafe {
+        std::slice::from_raw_parts_mut(
+            request.as_mut_ptr().cast::<u8>(),
+            request.len() * std::mem::size_of::<i32>(),
+        )
+    };
+    unsafe { eviocgmtslots(device.as_raw_fd(), request_bytes) }.map_err(io::Error::from)?;
+    Ok(request[1..].to_vec())
+}
+
+fn touch_snapshot_is_down(btn_touch_down: bool, mt_tracking_ids: &[i32]) -> bool {
+    btn_touch_down || mt_tracking_ids.iter().any(|tracking_id| *tracking_id >= 0)
 }
 
 fn wait_for_fd_readable(fd: RawFd, timeout: Duration) -> io::Result<bool> {
@@ -266,5 +305,15 @@ mod tests {
             wait_for_fd_readable(reader.as_raw_fd(), Duration::from_millis(100))
                 .expect("readable socket should be polled")
         );
+    }
+
+    #[test]
+    fn touch_snapshot_treats_active_mt_tracking_id_as_touch_down() {
+        assert!(touch_snapshot_is_down(false, &[42, -1, -1]));
+    }
+
+    #[test]
+    fn touch_snapshot_treats_all_released_slots_as_idle() {
+        assert!(!touch_snapshot_is_down(false, &[-1, -1, -1]));
     }
 }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -229,32 +229,76 @@ pub fn write_fixture_event(mut writer: impl Write, event: InputEvent) -> io::Res
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct WriteEventsResult {
-    pub reached_limit: bool,
     pub events_written: usize,
     pub frame_boundaries_written: usize,
+    pub ends_at_frame_boundary: bool,
 }
 
 impl WriteEventsResult {
     pub fn add(&mut self, other: Self) {
-        self.reached_limit |= other.reached_limit;
         self.events_written += other.events_written;
         self.frame_boundaries_written += other.frame_boundaries_written;
+        if other.events_written > 0 {
+            self.ends_at_frame_boundary = other.ends_at_frame_boundary;
+        }
     }
 }
 
 pub type WriteFixtureEventsResult = WriteEventsResult;
 
-pub fn write_fixture_events_with_limit(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DumpCaptureDecision {
+    Continue,
+    DrainStarted,
+    Finish,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DumpFrameBudget {
+    remaining: Option<usize>,
+    draining: bool,
+}
+
+impl DumpFrameBudget {
+    pub fn new(frame_boundaries: Option<usize>) -> Self {
+        Self {
+            remaining: frame_boundaries,
+            draining: false,
+        }
+    }
+
+    pub fn is_reached(self) -> bool {
+        matches!(self.remaining, Some(0))
+    }
+
+    pub fn observe_frame_boundary(&mut self) {
+        if let Some(remaining) = self.remaining.as_mut() {
+            *remaining = remaining.saturating_sub(1);
+        }
+    }
+
+    pub fn decide_after_batch(&mut self, touch_down: bool) -> DumpCaptureDecision {
+        if !self.is_reached() {
+            return DumpCaptureDecision::Continue;
+        }
+        if !touch_down {
+            return DumpCaptureDecision::Finish;
+        }
+        if self.draining {
+            DumpCaptureDecision::Continue
+        } else {
+            self.draining = true;
+            DumpCaptureDecision::DrainStarted
+        }
+    }
+}
+
+pub fn write_fixture_events_with_budget(
     mut writer: impl Write,
     events: impl IntoIterator<Item = InputEvent>,
-    remaining_frames: &mut Option<usize>,
+    frame_budget: &mut DumpFrameBudget,
 ) -> io::Result<WriteEventsResult> {
     let mut result = WriteEventsResult::default();
-
-    if matches!(remaining_frames, Some(0)) {
-        result.reached_limit = true;
-        return Ok(result);
-    }
 
     for event in events {
         let Some(line) = fixture_line_for_event(event)? else {
@@ -263,49 +307,34 @@ pub fn write_fixture_events_with_limit(
         let is_sync_boundary = is_sync_boundary(&line);
         write_event_line(&mut writer, &line)?;
         result.events_written += 1;
+        result.ends_at_frame_boundary = is_sync_boundary;
 
         if is_sync_boundary {
             result.frame_boundaries_written += 1;
-            if let Some(remaining) = remaining_frames.as_mut() {
-                *remaining = remaining.saturating_sub(1);
-                if *remaining == 0 {
-                    result.reached_limit = true;
-                    return Ok(result);
-                }
-            }
+            frame_budget.observe_frame_boundary();
         }
     }
 
     Ok(result)
 }
 
-pub fn write_raw_events_with_limit(
+pub fn write_raw_events_with_budget(
     mut writer: impl Write,
     events: impl IntoIterator<Item = InputEvent>,
-    remaining_frames: &mut Option<usize>,
+    frame_budget: &mut DumpFrameBudget,
 ) -> io::Result<WriteEventsResult> {
     let mut result = WriteEventsResult::default();
-
-    if matches!(remaining_frames, Some(0)) {
-        result.reached_limit = true;
-        return Ok(result);
-    }
 
     for event in events {
         let line = raw_line_for_event(event)?;
         let is_sync_boundary = is_sync_boundary(&line);
         write_event_line(&mut writer, &line)?;
         result.events_written += 1;
+        result.ends_at_frame_boundary = is_sync_boundary;
 
         if is_sync_boundary {
             result.frame_boundaries_written += 1;
-            if let Some(remaining) = remaining_frames.as_mut() {
-                *remaining = remaining.saturating_sub(1);
-                if *remaining == 0 {
-                    result.reached_limit = true;
-                    return Ok(result);
-                }
-            }
+            frame_budget.observe_frame_boundary();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,11 +218,19 @@ pub mod core {
         Passthrough,
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ContactPhase {
+        TapCandidate,
+        Motion,
+        ConsumedBySlider,
+    }
+
     #[derive(Debug, Clone)]
     struct SlotState {
         active: bool,
         tracking_id: Option<i32>,
         ownership: Ownership,
+        contact_phase: ContactPhase,
         start_x: Option<i32>,
         start_y: Option<i32>,
         current_x: Option<i32>,
@@ -238,6 +246,7 @@ pub mod core {
                 active: false,
                 tracking_id: None,
                 ownership: Ownership::Unknown,
+                contact_phase: ContactPhase::TapCandidate,
                 start_x: None,
                 start_y: None,
                 current_x: None,
@@ -252,6 +261,33 @@ pub mod core {
     impl SlotState {
         fn reset(&mut self) {
             *self = Self::default();
+        }
+
+        fn observe_position(&mut self, capabilities: Capabilities, swipe_min_distance: f32) {
+            if self.contact_phase != ContactPhase::TapCandidate {
+                return;
+            }
+
+            let moved_x = match (self.start_x, self.current_x) {
+                (Some(start), Some(current)) => {
+                    capabilities.x.normalize_delta(start, current).abs() >= swipe_min_distance
+                }
+                _ => false,
+            };
+            let moved_y = match (self.start_y, self.current_y) {
+                (Some(start), Some(current)) => {
+                    capabilities.y.normalize_delta(start, current).abs() >= swipe_min_distance
+                }
+                _ => false,
+            };
+
+            if moved_x || moved_y {
+                self.contact_phase = ContactPhase::Motion;
+            }
+        }
+
+        fn consume_by_slider(&mut self) {
+            self.contact_phase = ContactPhase::ConsumedBySlider;
         }
     }
 
@@ -418,6 +454,7 @@ pub mod core {
                         slot_state.active = true;
                         slot_state.tracking_id = Some(tracking_id);
                         slot_state.ownership = Ownership::Unknown;
+                        slot_state.contact_phase = ContactPhase::TapCandidate;
                         slot_state.started_at = timestamp;
                         slot_state.held_events.push(event);
                     }
@@ -428,19 +465,25 @@ pub mod core {
                         self.release_current_slot(event, timestamp, &mut output)?;
                     }
                     Event::X(x) => {
+                        let capabilities = self.caps;
+                        let swipe_min_distance = self.options.swipe_min_distance;
                         let slot_state = self.slot_mut(self.current_slot)?;
                         slot_state.current_x = Some(x);
                         if slot_state.active && slot_state.start_x.is_none() {
                             slot_state.start_x = Some(x);
                         }
+                        slot_state.observe_position(capabilities, swipe_min_distance);
                         self.route_event_for_current_slot(event, &mut output)?;
                     }
                     Event::Y(y) => {
+                        let capabilities = self.caps;
+                        let swipe_min_distance = self.options.swipe_min_distance;
                         let slot_state = self.slot_mut(self.current_slot)?;
                         slot_state.current_y = Some(y);
                         if slot_state.active && slot_state.start_y.is_none() {
                             slot_state.start_y = Some(y);
                         }
+                        slot_state.observe_position(capabilities, swipe_min_distance);
                         self.route_event_for_current_slot(event, &mut output)?;
                     }
                 }
@@ -645,22 +688,30 @@ pub mod core {
             };
 
             while position - anchor >= spec.step {
-                output.slider_steps.push(SliderStep {
-                    zone,
-                    direction: positive_slider_direction(spec.axis),
-                    slot,
-                    tracking_id,
-                });
+                push_slider_step(
+                    slot_state,
+                    output,
+                    SliderStep {
+                        zone,
+                        direction: positive_slider_direction(spec.axis),
+                        slot,
+                        tracking_id,
+                    },
+                );
                 anchor += spec.step;
             }
 
             while anchor - position >= spec.step {
-                output.slider_steps.push(SliderStep {
-                    zone,
-                    direction: negative_slider_direction(spec.axis),
-                    slot,
-                    tracking_id,
-                });
+                push_slider_step(
+                    slot_state,
+                    output,
+                    SliderStep {
+                        zone,
+                        direction: negative_slider_direction(spec.axis),
+                        slot,
+                        tracking_id,
+                    },
+                );
                 anchor -= spec.step;
             }
 
@@ -739,6 +790,11 @@ pub mod core {
         })
     }
 
+    fn push_slider_step(slot_state: &mut SlotState, output: &mut FrameOutput, step: SliderStep) {
+        slot_state.consume_by_slider();
+        output.slider_steps.push(step);
+    }
+
     fn classify_gesture(
         capabilities: Capabilities,
         slot: i32,
@@ -754,29 +810,52 @@ pub mod core {
         let dx = capabilities.x.normalize_delta(start_x, current_x);
         let dy = capabilities.y.normalize_delta(start_y, current_y);
 
-        let direction =
-            if dx.abs() < options.swipe_min_distance && dy.abs() < options.swipe_min_distance {
-                if !tap_duration_is_valid(state.started_at, released_at, options.tap_min_duration) {
-                    return None;
+        let final_direction = direction_for_displacement(dx, dy, options.swipe_min_distance);
+        let direction = match state.contact_phase {
+            ContactPhase::TapCandidate => match final_direction {
+                Some(direction) => direction,
+                None => {
+                    if !tap_duration_is_valid(
+                        state.started_at,
+                        released_at,
+                        options.tap_min_duration,
+                    ) {
+                        return None;
+                    }
+                    GestureDirection::Tap
                 }
-                GestureDirection::Tap
-            } else if dx.abs() >= dy.abs() {
-                if dx >= 0.0 {
-                    GestureDirection::Right
-                } else {
-                    GestureDirection::Left
-                }
-            } else if dy >= 0.0 {
-                GestureDirection::Down
-            } else {
-                GestureDirection::Up
-            };
+            },
+            ContactPhase::Motion => final_direction?,
+            ContactPhase::ConsumedBySlider => return None,
+        };
 
         Some(Gesture {
             zone,
             direction,
             slot,
             tracking_id: state.tracking_id?,
+        })
+    }
+
+    fn direction_for_displacement(
+        dx: f32,
+        dy: f32,
+        swipe_min_distance: f32,
+    ) -> Option<GestureDirection> {
+        if dx.abs() < swipe_min_distance && dy.abs() < swipe_min_distance {
+            return None;
+        }
+
+        Some(if dx.abs() >= dy.abs() {
+            if dx >= 0.0 {
+                GestureDirection::Right
+            } else {
+                GestureDirection::Left
+            }
+        } else if dy >= 0.0 {
+            GestureDirection::Down
+        } else {
+            GestureDirection::Up
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod core {
     use std::collections::BTreeSet;
     use std::time::Duration;
 
-    pub const DEFAULT_TAP_MIN_DURATION_MS: u64 = 80;
+    pub const DEFAULT_TAP_MIN_DURATION_MS: u64 = 40;
     pub const DEFAULT_SWIPE_MIN_DISTANCE: f32 = 0.02;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,13 @@ use edgepad::core::{
     SliderSpec, Zone,
 };
 use edgepad::device::{
-    discover_device_report, format_device_line, touchpad_candidates, wait_for_raw_device_events,
+    discover_device_report, format_device_line, physical_touch_is_down, touchpad_candidates,
+    wait_for_raw_device_events,
 };
 use edgepad::doctor::{run_doctor, DoctorCheck, DoctorConfig, DoctorReport, DoctorSection};
 use edgepad::dump::{
-    capabilities_from_raw_device, write_capture_header, write_fixture_events_with_limit,
-    write_raw_events_with_limit, WriteEventsResult,
+    capabilities_from_raw_device, write_capture_header, write_fixture_events_with_budget,
+    write_raw_events_with_budget, DumpCaptureDecision, DumpFrameBudget, WriteEventsResult,
 };
 use edgepad::proxy::{
     run_proxy, run_proxy_with_gesture_handler_and_ready, ProxyMode, ProxyRunConfig, ProxyRunLimit,
@@ -102,7 +103,7 @@ Options:
       --device auto|<event-node>  Physical touchpad selection
       --input-root <input-root>   Input device directory for auto-detect [default: /dev/input]
       --out <file.ev>             Output fixture path
-      --frames N                  Stop after N frame boundaries
+      --frames N                  Capture at least N frame boundaries, then stop when idle
       --raw                       Write raw evdev events instead of replay fixture events
 ";
 const PROXY_USAGE: &str = "usage: edgepad proxy --frames N (--dry-run | --uinput --grab) [--config <file> | --built-in-defaults] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F]";
@@ -880,10 +881,10 @@ impl DumpFormat {
 fn dump(
     device_path: &Path,
     out_path: &Path,
-    mut remaining_frames: Option<usize>,
+    requested_frames: Option<usize>,
     raw: bool,
 ) -> Result<(), String> {
-    let requested_frames = remaining_frames;
+    let mut frame_budget = DumpFrameBudget::new(requested_frames);
     let format = if raw {
         DumpFormat::Raw
     } else {
@@ -927,22 +928,38 @@ fn dump(
             no_events_warning_emitted = false;
         }
         let result = if raw {
-            write_raw_events_with_limit(&mut writer, events, &mut remaining_frames)
+            write_raw_events_with_budget(&mut writer, events, &mut frame_budget)
         } else {
-            write_fixture_events_with_limit(&mut writer, events, &mut remaining_frames)
+            write_fixture_events_with_budget(&mut writer, events, &mut frame_budget)
         }
         .map_err(|err| format!("failed to write {}: {err}", out_path.display()))?;
+        let can_finish_after_batch =
+            result.frame_boundaries_written > 0 && result.ends_at_frame_boundary;
         total.add(result);
-        if total.reached_limit {
-            print_dump_summary(
-                device_path,
-                out_path,
-                capabilities,
-                requested_frames,
-                total,
-                format,
-            );
-            return Ok(());
+        if frame_budget.is_reached() && can_finish_after_batch {
+            let touch_down = physical_touch_is_down(&device, capabilities).map_err(|err| {
+                format!(
+                    "failed to read current touch state from {}: {err}",
+                    device_path.display()
+                )
+            })?;
+            match frame_budget.decide_after_batch(touch_down) {
+                DumpCaptureDecision::Continue => {}
+                DumpCaptureDecision::DrainStarted => {
+                    eprintln!("edgepad dump: frame budget reached; release all contacts to finish");
+                }
+                DumpCaptureDecision::Finish => {
+                    print_dump_summary(
+                        device_path,
+                        out_path,
+                        capabilities,
+                        requested_frames,
+                        total,
+                        format,
+                    );
+                    return Ok(());
+                }
+            }
         }
     }
 }
@@ -981,6 +998,12 @@ fn print_dump_summary(
     }
     if let Some(requested_frames) = requested_frames {
         println!("requested_frame_boundaries: {requested_frames}");
+        println!(
+            "additional_frame_boundaries_after_budget: {}",
+            stats
+                .frame_boundaries_written
+                .saturating_sub(requested_frames)
+        );
     }
     println!(
         "written_frame_boundaries: {}",
@@ -1558,15 +1581,13 @@ fn print_replay_diagnosis(
             "diagnosis: no contact starts found; capture likely began after a finger was already down or no new touch started"
         );
         println!(
-            "diagnosis_hint: start dump before touching the pad, or use the gesture-release-then-center-finger flow for frame-limited captures"
+            "diagnosis_hint: start dump before touching the pad; frame-limited dump waits for active contacts to be released"
         );
     } else if stats.tracking_starts > stats.tracking_ends {
         println!(
-            "diagnosis: capture ended with active contact(s); frame budget likely stopped mid-contact"
+            "diagnosis: capture ended with active contact(s); input is incomplete or truncated"
         );
-        println!(
-            "diagnosis_hint: for edge gesture captures, perform the gesture, release it, then place a finger in the center until --frames finishes"
-        );
+        println!("diagnosis_hint: capture again and release all contacts before stopping");
     } else if stats.tracking_starts == 0 && stats.total_events == 0 {
         println!("diagnosis: no replay-relevant touch events found");
     } else if passthrough_events == 0 && gestures == 0 && slider_steps == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,9 @@ use edgepad::core::{
     AxisRange, Capabilities, EdgeWidths, Engine, EngineOptions, GestureDirection, SliderDirection,
     SliderSpec, Zone,
 };
-use edgepad::device::{discover_device_report, format_device_line, touchpad_candidates};
+use edgepad::device::{
+    discover_device_report, format_device_line, touchpad_candidates, wait_for_raw_device_events,
+};
 use edgepad::doctor::{run_doctor, DoctorCheck, DoctorConfig, DoctorReport, DoctorSection};
 use edgepad::dump::{
     capabilities_from_raw_device, write_capture_header, write_fixture_events_with_limit,
@@ -93,6 +95,9 @@ const DUMP_HELP: &str = "\
 Usage:
   edgepad dump --device auto|<event-node> --out <file.ev> [--input-root <input-root>] [--frames N] [--raw]
 
+The physical device must not be grabbed by another process.
+Stop edgepad.service before capturing when the daemon owns the touchpad.
+
 Options:
       --device auto|<event-node>  Physical touchpad selection
       --input-root <input-root>   Input device directory for auto-detect [default: /dev/input]
@@ -154,6 +159,7 @@ Options:
       --service <unit>            systemd user unit to inspect [default: edgepad.service]
 ";
 const DAEMON_IDLE_DRAIN_TIMEOUT: Duration = Duration::from_millis(1000);
+const DUMP_FIRST_EVENT_WARNING_TIMEOUT: Duration = Duration::from_secs(3);
 const DAEMON_SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const DAEMON_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(30);
 const DAEMON_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(500);
@@ -893,13 +899,33 @@ fn dump(
         .map_err(|err| format!("failed to write {}: {err}", out_path.display()))?;
     let mut total = WriteEventsResult::default();
 
-    loop {
-        let events = device.fetch_events().map_err(|err| {
+    eprintln!("edgepad dump: device={}", device_path.display());
+    eprintln!("edgepad dump: waiting for input events");
+    let mut no_events_warning_emitted =
+        !wait_for_raw_device_events(&device, DUMP_FIRST_EVENT_WARNING_TIMEOUT).map_err(|err| {
             format!(
-                "failed to read events from {}: {err}",
+                "failed to wait for events from {}: {err}",
                 device_path.display()
             )
         })?;
+    if no_events_warning_emitted {
+        eprintln!("{}", dump_no_events_warning(device_path));
+    }
+
+    loop {
+        let mut events = device
+            .fetch_events()
+            .map_err(|err| {
+                format!(
+                    "failed to read events from {}: {err}",
+                    device_path.display()
+                )
+            })?
+            .peekable();
+        if no_events_warning_emitted && events.peek().is_some() {
+            eprintln!("edgepad dump: input events received; capture started");
+            no_events_warning_emitted = false;
+        }
         let result = if raw {
             write_raw_events_with_limit(&mut writer, events, &mut remaining_frames)
         } else {
@@ -919,6 +945,14 @@ fn dump(
             return Ok(());
         }
     }
+}
+
+fn dump_no_events_warning(device_path: &Path) -> String {
+    format!(
+        "edgepad dump: no events received from {} after {}s; device may be grabbed; continuing to wait (stop edgepad.service before capturing)",
+        device_path.display(),
+        DUMP_FIRST_EVENT_WARNING_TIMEOUT.as_secs()
+    )
 }
 
 fn print_dump_summary(
@@ -1587,6 +1621,14 @@ mod tests {
         assert_eq!(
             dump_next_command(DumpFormat::Replay, Path::new("bug.ev")),
             "edgepad replay bug.ev"
+        );
+    }
+
+    #[test]
+    fn dump_no_events_warning_explains_likely_grab() {
+        assert_eq!(
+            dump_no_events_warning(Path::new("/dev/input/event10")),
+            "edgepad dump: no events received from /dev/input/event10 after 3s; device may be grabbed; continuing to wait (stop edgepad.service before capturing)"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use edgepad::replay::{parse_replay_file, replay_stats, run_frames};
 use edgepad::status::{run_status, StatusConfig, StatusReport};
 use evdev::raw_stream::RawDevice;
 
-const USAGE: &str = "usage: edgepad replay <fixture.ev> [--config <file> | --built-in-defaults] | edgepad replay-raw <raw.ev> [--config <file> | --built-in-defaults] | edgepad devices [--root <input-root>] [--all] | edgepad status [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--service <unit>] | edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>] | edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw] | edgepad proxy --frames N (--dry-run | --uinput --grab) [--config <file> | --built-in-defaults] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F] | edgepad daemon [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F]";
+const USAGE: &str = "usage: edgepad replay <fixture.ev> [--config <file> | --built-in-defaults] | edgepad replay-raw <raw.ev> [--config <file> | --built-in-defaults] | edgepad devices [--input-root <input-root>] [--all] | edgepad status [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--service <unit>] | edgepad doctor [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--uinput <path>] [--service <unit>] | edgepad dump --device auto|<event-node> --out <file.ev> [--input-root <input-root>] [--frames N] [--raw] | edgepad proxy --frames N (--dry-run | --uinput --grab) [--config <file> | --built-in-defaults] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F] | edgepad daemon [--config <file>] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F]";
 const HELP: &str = "\
 Usage:
   edgepad <command> [options]
@@ -78,26 +78,27 @@ Options:
                              [default: $XDG_CONFIG_HOME/edgepad/edgepad.toml or ~/.config/edgepad/edgepad.toml]
       --built-in-defaults    Use the built-in recognizer profile instead of a config
 ";
-const DEVICES_USAGE: &str = "usage: edgepad devices [--root <input-root>] [--all]";
+const DEVICES_USAGE: &str = "usage: edgepad devices [--input-root <input-root>] [--all]";
 const DEVICES_HELP: &str = "\
 Usage:
-  edgepad devices [--root <input-root>] [--all]
+  edgepad devices [--input-root <input-root>] [--all]
 
 Options:
-      --root <input-root>  Input device directory [default: /dev/input]
-      --all                Show all readable event devices, not only touchpad candidates
+      --input-root <input-root>  Input device directory [default: /dev/input]
+      --root <input-root>        Alias for --input-root
+      --all                      Show all readable event devices, not only touchpad candidates
 ";
-const DUMP_USAGE: &str =
-    "usage: edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw]";
+const DUMP_USAGE: &str = "usage: edgepad dump --device auto|<event-node> --out <file.ev> [--input-root <input-root>] [--frames N] [--raw]";
 const DUMP_HELP: &str = "\
 Usage:
-  edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw]
+  edgepad dump --device auto|<event-node> --out <file.ev> [--input-root <input-root>] [--frames N] [--raw]
 
 Options:
-      --device <event-node>  Physical touchpad event node to read
-      --out <file.ev>        Output fixture path
-      --frames N             Stop after N frame boundaries
-      --raw                  Write raw evdev events instead of replay fixture events
+      --device auto|<event-node>  Physical touchpad selection
+      --input-root <input-root>   Input device directory for auto-detect [default: /dev/input]
+      --out <file.ev>             Output fixture path
+      --frames N                  Stop after N frame boundaries
+      --raw                       Write raw evdev events instead of replay fixture events
 ";
 const PROXY_USAGE: &str = "usage: edgepad proxy --frames N (--dry-run | --uinput --grab) [--config <file> | --built-in-defaults] [--device auto|<event-node>] [--input-root <input-root>] [--edge-width F]";
 const PROXY_HELP: &str = "\
@@ -235,7 +236,8 @@ fn run() -> Result<i32, String> {
                 return Ok(0);
             }
             let args = parse_dump_args(args.into_iter())?;
-            dump(&args.device, &args.out, args.frames, args.raw).map(|()| 0)
+            let device_path = args.device.resolve(&args.input_root)?;
+            dump(&device_path, &args.out, args.frames, args.raw).map(|()| 0)
         }
         Some("proxy") => {
             let args = args.collect::<Vec<_>>();
@@ -273,7 +275,8 @@ struct DeviceArgs {
 }
 
 struct DumpArgs {
-    device: PathBuf,
+    device: DeviceConfig,
+    input_root: PathBuf,
     out: PathBuf,
     frames: Option<usize>,
     raw: bool,
@@ -371,7 +374,7 @@ fn parse_devices_args(mut args: impl Iterator<Item = String>) -> Result<DeviceAr
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--root" => {
+            "--input-root" | "--root" => {
                 root = args.next().ok_or_else(|| DEVICES_USAGE.to_string())?.into();
             }
             "--all" => show_all = true,
@@ -445,13 +448,20 @@ fn parse_status_args(mut args: impl Iterator<Item = String>) -> Result<StatusCon
 
 fn parse_dump_args(mut args: impl Iterator<Item = String>) -> Result<DumpArgs, String> {
     let mut device = None;
+    let mut input_root = PathBuf::from("/dev/input");
     let mut out = None;
     let mut frames = None;
     let mut raw = false;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--device" => device = Some(args.next().ok_or_else(|| DUMP_USAGE.to_string())?.into()),
+            "--device" => {
+                let raw_value = args.next().ok_or_else(|| DUMP_USAGE.to_string())?;
+                device = Some(DeviceConfig::parse(&raw_value)?);
+            }
+            "--input-root" => {
+                input_root = args.next().ok_or_else(|| DUMP_USAGE.to_string())?.into();
+            }
             "--out" => out = Some(args.next().ok_or_else(|| DUMP_USAGE.to_string())?.into()),
             "--frames" => {
                 let raw_value = args.next().ok_or_else(|| DUMP_USAGE.to_string())?;
@@ -465,6 +475,7 @@ fn parse_dump_args(mut args: impl Iterator<Item = String>) -> Result<DumpArgs, S
 
     Ok(DumpArgs {
         device: device.ok_or_else(|| DUMP_USAGE.to_string())?,
+        input_root,
         out: out.ok_or_else(|| DUMP_USAGE.to_string())?,
         frames,
         raw,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -13,7 +12,7 @@ use crate::core::{
     Capabilities, EdgeWidths, Engine, EngineOptions, Gesture, GestureDirection, ResyncContact,
     SliderDirection, SliderSpec, SliderStep, Zone,
 };
-use crate::device::wait_for_raw_device_events;
+use crate::device::{mt_slot_values, physical_touch_is_down, wait_for_raw_device_events};
 use crate::dump::capabilities_from_raw_device;
 use crate::raw::{
     extract_core_events, is_pointer_button_code, route_raw_frame, route_resync_contacts, RawEvent,
@@ -24,9 +23,7 @@ use crate::raw::{
 use crate::uinput::{
     build_virtual_touchpad, UinputEventWriter, UinputRawOutputSink, VirtualTouchpadSpec,
 };
-use evdev::{raw_stream::RawDevice, KeyCode, PropType};
-
-nix::ioctl_read_buf!(eviocgmtslots, b'E', 0x0a, u8);
+use evdev::{raw_stream::RawDevice, PropType};
 
 pub use crate::config::DEFAULT_EDGE_WIDTH;
 
@@ -399,7 +396,9 @@ fn ensure_physical_touchpad_idle_at_start(
     device: &RawDevice,
     capabilities: Capabilities,
 ) -> Result<(), String> {
-    if !physical_touch_is_down(device, capabilities)? {
+    if !physical_touch_is_down(device, Some(capabilities))
+        .map_err(|err| format!("failed to read current touch state before live proxy: {err}"))?
+    {
         return Ok(());
     }
 
@@ -409,52 +408,16 @@ fn ensure_physical_touchpad_idle_at_start(
     ))
 }
 
-fn physical_touch_is_down(device: &RawDevice, capabilities: Capabilities) -> Result<bool, String> {
-    let key_state = device.get_key_state().map_err(|err| {
-        format!("failed to read current touch key state before live proxy: {err}")
-    })?;
-    let tracking_ids = mt_tracking_ids(device, capabilities)?;
-    Ok(physical_touch_snapshot_is_down(
-        key_state.contains(KeyCode::BTN_TOUCH),
-        &tracking_ids,
-    ))
-}
-
-fn physical_touch_snapshot_is_down(btn_touch_down: bool, mt_tracking_ids: &[i32]) -> bool {
-    btn_touch_down || mt_tracking_ids.iter().any(|tracking_id| *tracking_id >= 0)
-}
-
-fn mt_tracking_ids(device: &RawDevice, capabilities: Capabilities) -> Result<Vec<i32>, String> {
-    mt_slot_values(device, capabilities, ABS_MT_TRACKING_ID)
-}
-
-fn mt_slot_values(
-    device: &RawDevice,
-    capabilities: Capabilities,
-    axis_code: u16,
-) -> Result<Vec<i32>, String> {
-    let slot_count = (capabilities.slot_max - capabilities.slot_min + 1) as usize;
-    let mut request = vec![0_i32; slot_count + 1];
-    request[0] = axis_code as i32;
-    let request_bytes = unsafe {
-        std::slice::from_raw_parts_mut(
-            request.as_mut_ptr().cast::<u8>(),
-            request.len() * std::mem::size_of::<i32>(),
-        )
-    };
-    unsafe { eviocgmtslots(device.as_raw_fd(), request_bytes) }.map_err(|err| {
-        format!("failed to read current multitouch slot axis {axis_code:#x}: {err}")
-    })?;
-    Ok(request[1..].to_vec())
-}
-
 fn read_resync_contacts(
     device: &RawDevice,
     capabilities: Capabilities,
 ) -> Result<Vec<ResyncContact>, String> {
-    let tracking_ids = mt_slot_values(device, capabilities, ABS_MT_TRACKING_ID)?;
-    let x_values = mt_slot_values(device, capabilities, ABS_MT_POSITION_X)?;
-    let y_values = mt_slot_values(device, capabilities, ABS_MT_POSITION_Y)?;
+    let tracking_ids = mt_slot_values(device, capabilities, ABS_MT_TRACKING_ID)
+        .map_err(|err| format!("failed to read current multitouch tracking IDs: {err}"))?;
+    let x_values = mt_slot_values(device, capabilities, ABS_MT_POSITION_X)
+        .map_err(|err| format!("failed to read current multitouch X positions: {err}"))?;
+    let y_values = mt_slot_values(device, capabilities, ABS_MT_POSITION_Y)
+        .map_err(|err| format!("failed to read current multitouch Y positions: {err}"))?;
     Ok(resync_contacts_from_slot_values(
         capabilities,
         &tracking_ids,
@@ -1577,16 +1540,6 @@ mod tests {
             }),
             Err("proxy frame limit must be a positive integer".to_string())
         );
-    }
-
-    #[test]
-    fn physical_touch_snapshot_treats_active_mt_tracking_id_as_touch_down() {
-        assert!(physical_touch_snapshot_is_down(false, &[42, -1, -1]));
-    }
-
-    #[test]
-    fn physical_touch_snapshot_treats_all_released_slots_as_idle() {
-        assert!(!physical_touch_snapshot_is_down(false, &[-1, -1, -1]));
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -13,6 +13,7 @@ use crate::core::{
     Capabilities, EdgeWidths, Engine, EngineOptions, Gesture, GestureDirection, ResyncContact,
     SliderDirection, SliderSpec, SliderStep, Zone,
 };
+use crate::device::wait_for_raw_device_events;
 use crate::dump::capabilities_from_raw_device;
 use crate::raw::{
     extract_core_events, is_pointer_button_code, route_raw_frame, route_resync_contacts, RawEvent,
@@ -672,23 +673,9 @@ fn fetch_proxy_events(
     timeout: Option<Duration>,
 ) -> Result<Option<Vec<ProxyInputEvent>>, String> {
     if let Some(timeout) = timeout {
-        let timeout_ms = poll_timeout_ms(timeout);
-        let mut poll_fd = libc::pollfd {
-            fd: device.as_raw_fd(),
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        let ready = loop {
-            let result = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
-            if result >= 0 {
-                break result;
-            }
-            let err = std::io::Error::last_os_error();
-            if err.kind() != std::io::ErrorKind::Interrupted {
-                return Err(format!("failed to wait for proxy events: {err}"));
-            }
-        };
-        if ready == 0 {
+        let ready = wait_for_raw_device_events(device, timeout)
+            .map_err(|err| format!("failed to wait for proxy events: {err}"))?;
+        if !ready {
             return Ok(None);
         }
     }
@@ -708,15 +695,6 @@ fn fetch_proxy_events(
         })
         .collect::<Result<Vec<_>, String>>()?;
     Ok(Some(events))
-}
-
-fn poll_timeout_ms(timeout: Duration) -> i32 {
-    let millis = timeout.as_millis();
-    if millis == 0 {
-        0
-    } else {
-        millis.min(i32::MAX as u128) as i32
-    }
 }
 
 fn process_proxy_raw_frame<S, H>(

--- a/tests/core_invariants.rs
+++ b/tests/core_invariants.rs
@@ -92,6 +92,35 @@ fn claimed_edge_touch_does_not_emit_initial_down_to_passthrough() {
 }
 
 #[test]
+fn edge_touch_that_leaves_tap_slop_and_returns_emits_no_gesture() {
+    let mut engine = Engine::new(test_caps(), EdgeWidths::all(0.10));
+
+    engine
+        .process_frame(&[
+            Event::slot(0),
+            Event::tracking_id(21),
+            Event::x(20),
+            Event::y(300),
+        ])
+        .expect("left edge contact is valid");
+
+    engine
+        .process_frame(&[Event::slot(0), Event::x(60)])
+        .expect("movement beyond tap slop remains claimed");
+    engine
+        .process_frame(&[Event::slot(0), Event::x(20)])
+        .expect("return to the starting point remains claimed");
+
+    let up = engine
+        .process_frame(&[Event::slot(0), Event::tracking_id(-1)])
+        .expect("cancelled gesture releases cleanly");
+
+    assert!(up.gestures.is_empty());
+    assert!(up.slider_steps.is_empty());
+    assert!(up.passthrough.is_empty());
+}
+
+#[test]
 fn buttonpad_press_promotes_claimed_contact_and_cancels_edge_gesture() {
     let mut engine = Engine::new(test_caps(), EdgeWidths::all(0.10));
     engine.set_buttonpad(true);
@@ -290,6 +319,50 @@ fn slider_edge_touch_emits_steps_during_motion_without_release_swipe() {
 }
 
 #[test]
+fn slider_that_emits_steps_and_returns_to_start_does_not_emit_tap() {
+    let mut engine = Engine::with_sliders(
+        test_caps(),
+        EdgeWidths::all(0.10),
+        vec![SliderSpec {
+            zone: Zone::Left,
+            axis: SliderAxis::Vertical,
+            step: 0.09,
+        }],
+    );
+
+    engine
+        .process_frame(&[
+            Event::slot(0),
+            Event::tracking_id(23),
+            Event::x(20),
+            Event::y(300),
+        ])
+        .expect("left slider contact is valid");
+
+    let forward = engine
+        .process_frame(&[Event::slot(0), Event::y(510)])
+        .expect("forward slider motion emits steps");
+    assert_eq!(forward.slider_steps.len(), 3);
+
+    let returned = engine
+        .process_frame(&[Event::slot(0), Event::y(300)])
+        .expect("return slider motion emits reverse steps");
+    assert!(!returned.slider_steps.is_empty());
+    assert!(returned
+        .slider_steps
+        .iter()
+        .all(|step| step.direction == SliderDirection::Up));
+
+    let up = engine
+        .process_frame(&[Event::slot(0), Event::tracking_id(-1)])
+        .expect("returned slider contact releases cleanly");
+
+    assert!(up.gestures.is_empty());
+    assert!(up.slider_steps.is_empty());
+    assert!(up.passthrough.is_empty());
+}
+
+#[test]
 fn buttonpad_press_keeps_emitted_slider_steps_but_cancels_future_steps_and_gesture() {
     let mut engine = Engine::with_sliders(
         test_caps(),
@@ -366,6 +439,41 @@ fn slider_edge_touch_still_emits_tap_on_release() {
     assert_eq!(up.gestures.len(), 1);
     assert_eq!(up.gestures[0].zone, Zone::Left);
     assert_eq!(up.gestures[0].direction, GestureDirection::Tap);
+}
+
+#[test]
+fn slider_step_inside_tap_slop_consumes_release_gesture() {
+    let mut engine = Engine::with_sliders(
+        test_caps(),
+        EdgeWidths::all(0.10),
+        vec![SliderSpec {
+            zone: Zone::Left,
+            axis: SliderAxis::Vertical,
+            step: 0.01,
+        }],
+    );
+
+    engine
+        .process_frame(&[
+            Event::slot(0),
+            Event::tracking_id(24),
+            Event::x(20),
+            Event::y(300),
+        ])
+        .expect("left slider contact is valid");
+
+    let moved = engine
+        .process_frame(&[Event::slot(0), Event::y(310)])
+        .expect("movement inside tap slop emits a configured slider step");
+    assert_eq!(moved.slider_steps.len(), 1);
+
+    let up = engine
+        .process_frame(&[Event::slot(0), Event::tracking_id(-1)])
+        .expect("consumed slider contact releases cleanly");
+
+    assert!(up.gestures.is_empty());
+    assert!(up.slider_steps.is_empty());
+    assert!(up.passthrough.is_empty());
 }
 
 #[test]

--- a/tests/device_cli.rs
+++ b/tests/device_cli.rs
@@ -13,7 +13,7 @@ fn devices_cli_handles_empty_input_root_without_touching_real_hardware() {
 
     let output = edgepad()
         .arg("devices")
-        .arg("--root")
+        .arg("--input-root")
         .arg(&root)
         .output()
         .expect("edgepad binary should run");
@@ -26,6 +26,21 @@ fn devices_cli_handles_empty_input_root_without_touching_real_hardware() {
 #[test]
 fn devices_cli_handles_missing_input_root_without_touching_real_hardware() {
     let root = unique_temp_dir("edgepad-devices-cli-missing");
+    let _ = fs::remove_dir_all(&root);
+
+    let output = edgepad()
+        .arg("devices")
+        .arg("--input-root")
+        .arg(&root)
+        .output()
+        .expect("edgepad binary should run");
+
+    assert_no_devices_success(output);
+}
+
+#[test]
+fn devices_cli_accepts_root_alias() {
+    let root = unique_temp_dir("edgepad-devices-cli-root-alias");
     let _ = fs::remove_dir_all(&root);
 
     let output = edgepad()
@@ -47,7 +62,7 @@ fn devices_cli_reports_unreadable_event_nodes_as_permission_hint() {
 
     let output = edgepad()
         .arg("devices")
-        .arg("--root")
+        .arg("--input-root")
         .arg(&root)
         .output()
         .expect("edgepad binary should run");

--- a/tests/doctor_cli.rs
+++ b/tests/doctor_cli.rs
@@ -42,7 +42,7 @@ fn doctor_cli_checks_config_and_action_executables() {
     assert!(stdout.contains("file"), "stdout was: {stdout}");
     assert!(
         stdout.contains(
-            "device auto, edge width 10.0%, tap min 80ms, swipe min 2.0%, 1 gesture binding, 0 sliders"
+            "device auto, edge width 10.0%, tap min 40ms, swipe min 2.0%, 1 gesture binding, 0 sliders"
         ),
         "stdout was: {stdout}"
     );

--- a/tests/dump_cli.rs
+++ b/tests/dump_cli.rs
@@ -17,8 +17,49 @@ fn dump_cli_requires_device_and_out_arguments() {
     assert!(!output.status.success(), "dump without --out should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw]"),
+        stderr.contains("edgepad dump --device auto|<event-node> --out <file.ev> [--input-root <input-root>] [--frames N] [--raw]"),
         "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn dump_cli_resolves_auto_device_under_input_root() {
+    let root = unique_temp_path("edgepad-dump-cli-auto-input-root");
+    let out_path = unique_temp_path("edgepad-dump-cli-auto-output.ev");
+    let _ = std::fs::remove_dir_all(&root);
+    let _ = std::fs::remove_file(&out_path);
+    std::fs::create_dir_all(&root).expect("input root should be created");
+
+    let output = edgepad()
+        .arg("dump")
+        .arg("--device")
+        .arg("auto")
+        .arg("--input-root")
+        .arg(&root)
+        .arg("--out")
+        .arg(&out_path)
+        .output()
+        .expect("edgepad binary should run");
+
+    std::fs::remove_dir_all(&root).expect("input root should be removed");
+
+    assert!(!output.status.success(), "empty input root should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("device=auto found no event devices"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains(&root.display().to_string()),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        !stderr.contains("failed to open device auto"),
+        "auto must be resolved before the device is opened, stderr was: {stderr}"
+    );
+    assert!(
+        !out_path.exists(),
+        "failed auto-detection must not create output file"
     );
 }
 
@@ -174,7 +215,7 @@ fn dump_cli_rejects_unknown_dump_flag_before_device_open() {
     assert!(!output.status.success(), "unknown dump flag should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw]"),
+        stderr.contains("edgepad dump --device auto|<event-node> --out <file.ev> [--input-root <input-root>] [--frames N] [--raw]"),
         "stderr was: {stderr}"
     );
     assert!(

--- a/tests/dump_events.rs
+++ b/tests/dump_events.rs
@@ -1,8 +1,8 @@
 use edgepad::core::{AxisRange, Capabilities};
 use edgepad::dump::{
     fixture_line_for_event as format_fixture_line, raw_line_for_event as format_raw_line,
-    write_capture_header, write_fixture_event, write_fixture_events_with_limit,
-    write_raw_events_with_limit,
+    write_capture_header, write_fixture_event, write_fixture_events_with_budget,
+    write_raw_events_with_budget, DumpCaptureDecision, DumpFrameBudget,
 };
 use evdev::{AbsoluteAxisCode, EventType, InputEvent, KeyCode, MiscCode, SynchronizationCode};
 
@@ -132,7 +132,7 @@ fn write_fixture_event_adds_blank_line_after_sync_boundaries() {
 }
 
 #[test]
-fn write_fixture_events_with_limit_stops_after_requested_sync_boundaries() {
+fn write_fixture_events_with_budget_keeps_complete_fetched_batch() {
     let mut out = Vec::new();
     let events = vec![
         InputEvent::new(EventType::ABSOLUTE.0, AbsoluteAxisCode::ABS_MT_SLOT.0, 0),
@@ -162,18 +162,47 @@ fn write_fixture_events_with_limit_stops_after_requested_sync_boundaries() {
             0,
         ),
     ];
-    let mut remaining_frames = Some(2);
+    let mut frame_budget = DumpFrameBudget::new(Some(2));
 
-    let result = write_fixture_events_with_limit(&mut out, events, &mut remaining_frames)
+    let result = write_fixture_events_with_budget(&mut out, events, &mut frame_budget)
         .expect("events should write");
 
-    assert!(result.reached_limit);
-    assert_eq!(result.events_written, 4);
-    assert_eq!(result.frame_boundaries_written, 2);
-    assert_eq!(remaining_frames, Some(0));
+    assert!(frame_budget.is_reached());
+    assert_eq!(result.events_written, 6);
+    assert_eq!(result.frame_boundaries_written, 3);
+    assert!(result.ends_at_frame_boundary);
+    assert_eq!(
+        frame_budget.decide_after_batch(false),
+        DumpCaptureDecision::Finish
+    );
     assert_eq!(
         String::from_utf8(out).expect("fixture output should be utf8"),
-        "ABS_MT_SLOT 0\nSYN_REPORT 0\n\nABS_MT_POSITION_X 42\nSYN_DROPPED 0\n\n"
+        "ABS_MT_SLOT 0\nSYN_REPORT 0\n\nABS_MT_POSITION_X 42\nSYN_DROPPED 0\n\nABS_MT_POSITION_Y 99\nSYN_REPORT 0\n\n"
+    );
+}
+
+#[test]
+fn frame_budget_waits_for_active_contact_to_release() {
+    let mut frame_budget = DumpFrameBudget::new(Some(2));
+
+    frame_budget.observe_frame_boundary();
+    assert_eq!(
+        frame_budget.decide_after_batch(true),
+        DumpCaptureDecision::Continue
+    );
+
+    frame_budget.observe_frame_boundary();
+    assert_eq!(
+        frame_budget.decide_after_batch(true),
+        DumpCaptureDecision::DrainStarted
+    );
+    assert_eq!(
+        frame_budget.decide_after_batch(true),
+        DumpCaptureDecision::Continue
+    );
+    assert_eq!(
+        frame_budget.decide_after_batch(false),
+        DumpCaptureDecision::Finish
     );
 }
 
@@ -270,7 +299,7 @@ fn raw_line_for_event_falls_back_to_numeric_codes_for_unknown_events() {
 }
 
 #[test]
-fn write_raw_events_with_limit_keeps_all_events_and_stops_after_sync_boundaries() {
+fn write_raw_events_with_budget_keeps_events_after_budget_until_a_complete_frame() {
     let mut out = Vec::new();
     let events = vec![
         InputEvent::new(EventType::KEY.0, KeyCode::BTN_TOUCH.0, 1),
@@ -289,17 +318,17 @@ fn write_raw_events_with_limit_keeps_all_events_and_stops_after_sync_boundaries(
         ),
         InputEvent::new(EventType::ABSOLUTE.0, AbsoluteAxisCode::ABS_Y.0, 320),
     ];
-    let mut remaining_frames = Some(2);
+    let mut frame_budget = DumpFrameBudget::new(Some(2));
 
-    let result = write_raw_events_with_limit(&mut out, events, &mut remaining_frames)
+    let result = write_raw_events_with_budget(&mut out, events, &mut frame_budget)
         .expect("events should write");
 
-    assert!(result.reached_limit);
-    assert_eq!(result.events_written, 6);
+    assert!(frame_budget.is_reached());
+    assert_eq!(result.events_written, 7);
     assert_eq!(result.frame_boundaries_written, 2);
-    assert_eq!(remaining_frames, Some(0));
+    assert!(!result.ends_at_frame_boundary);
     assert_eq!(
         String::from_utf8(out).expect("raw output should be utf8"),
-        "EV_KEY BTN_TOUCH 1\nEV_ABS ABS_X 640\nEV_ABS ABS_MT_SLOT 1\nEV_SYN SYN_REPORT 0 0\n\nEV_KEY BTN_TOUCH 0\nEV_SYN SYN_DROPPED 0 0\n\n"
+        "EV_KEY BTN_TOUCH 1\nEV_ABS ABS_X 640\nEV_ABS ABS_MT_SLOT 1\nEV_SYN SYN_REPORT 0 0\n\nEV_KEY BTN_TOUCH 0\nEV_SYN SYN_DROPPED 0 0\n\nEV_ABS ABS_Y 320\n"
     );
 }

--- a/tests/help_cli.rs
+++ b/tests/help_cli.rs
@@ -60,7 +60,10 @@ fn root_version_flags_print_package_version() {
 #[test]
 fn subcommand_help_flags_print_command_help() {
     for (command, usage) in [
-        ("devices", "edgepad devices [--root <input-root>] [--all]"),
+        (
+            "devices",
+            "edgepad devices [--input-root <input-root>] [--all]",
+        ),
         (
             "status",
             "edgepad status [--config <file>] [--device auto|<event-node>] [--input-root <input-root>]",
@@ -75,7 +78,7 @@ fn subcommand_help_flags_print_command_help() {
         ),
         (
             "dump",
-            "edgepad dump --device <event-node> --out <file.ev> [--frames N] [--raw]",
+            "edgepad dump --device auto|<event-node> --out <file.ev> [--input-root <input-root>] [--frames N] [--raw]",
         ),
         (
             "proxy",

--- a/tests/help_cli.rs
+++ b/tests/help_cli.rs
@@ -135,4 +135,8 @@ fn dump_help_explains_running_daemon_limit() {
         stdout.contains("Stop edgepad.service before capturing"),
         "stdout was: {stdout}"
     );
+    assert!(
+        stdout.contains("Capture at least N frame boundaries, then stop when idle"),
+        "stdout was: {stdout}"
+    );
 }

--- a/tests/help_cli.rs
+++ b/tests/help_cli.rs
@@ -116,3 +116,23 @@ fn subcommand_help_flags_print_command_help() {
         }
     }
 }
+
+#[test]
+fn dump_help_explains_running_daemon_limit() {
+    let output = edgepad()
+        .arg("dump")
+        .arg("--help")
+        .output()
+        .expect("edgepad binary should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("must not be grabbed by another process"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("Stop edgepad.service before capturing"),
+        "stdout was: {stdout}"
+    );
+}

--- a/tests/raw_routing.rs
+++ b/tests/raw_routing.rs
@@ -267,7 +267,7 @@ fn route_raw_frame_suppresses_short_timed_tap() {
         &mut engine,
         &RawFrame::new_at(
             vec![RawEvent::abs_mt_slot(0), RawEvent::abs_mt_tracking_id(-1)],
-            Duration::from_millis(1079),
+            Duration::from_millis(1039),
         ),
     )
     .expect("edge release should route");

--- a/tests/replay_cli.rs
+++ b/tests/replay_cli.rs
@@ -238,7 +238,7 @@ SYN_REPORT 0
 }
 
 #[test]
-fn replay_cli_explains_frame_budget_stopping_mid_contact_without_bad_lift_hint() {
+fn replay_cli_explains_capture_ending_mid_contact() {
     let path = unique_temp_path("edgepad-replay-active-at-end.ev");
     fs::write(
         &path,
@@ -271,15 +271,13 @@ SYN_REPORT 0
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("diagnosis: capture ended with active contact(s); frame budget likely stopped mid-contact"),
+        stdout.contains(
+            "diagnosis: capture ended with active contact(s); input is incomplete or truncated"
+        ),
         "stdout was: {stdout}"
     );
     assert!(
-        stdout.contains("diagnosis_hint: for edge gesture captures, perform the gesture, release it, then place a finger in the center until --frames finishes"),
-        "stdout was: {stdout}"
-    );
-    assert!(
-        !stdout.contains("lift fingers before capture stops"),
+        stdout.contains("diagnosis_hint: capture again and release all contacts before stopping"),
         "stdout was: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary

- prevent taps after leaving tap movement tolerance or emitting slider steps
- improve `edgepad dump` device selection, grabbed-device diagnostics, and contact-complete capture
- lower the default minimum tap duration from 80 ms to 40 ms
- bump the crate version to 0.2.3

## Validation

- real-device dump smoke test passed
- cargo fmt, clippy, tests, and release build
- Nix flake checks and package build
- installer dry-runs and actionlint